### PR TITLE
Feature: add "xunit" reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Packages
 * `-p, --production` Analyzes only production dependencies.
 * `-d, --development` Analyzes only development dependencies.
 * `-t, --direct` Analyzes only direct dependencies (depth = 1).
-* `-f, --format <format>` Report format, csv, text, or json (default = "text").
+* `-f, --format <format>` Report format, csv, text, json or xunit (default = "text").
 * `-r, --report <report>` Report type, summary or detailed (default = "summary").
 * `-a, --allow <licenses>` Semicolon separated list of allowed licenses. Must conform to [SPDX](https://spdx.org/licenses) specifications.
 * `-e, --exclude <packages>` Semicolon separated list of package names to be excluded from the analysis. Regex expressions are supported.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Packages
 * `-p, --production` Analyzes only production dependencies.
 * `-d, --development` Analyzes only development dependencies.
 * `-t, --direct` Analyzes only direct dependencies (depth = 1).
-* `-f, --format <format>` Report format, csv, text, json or xunit (default = "text").
+* `-f, --format <format>` Report format, csv, text, json, or xunit (default = "text").
 * `-r, --report <report>` Report type, summary or detailed (default = "summary").
 * `-a, --allow <licenses>` Semicolon separated list of allowed licenses. Must conform to [SPDX](https://spdx.org/licenses) specifications.
 * `-e, --exclude <packages>` Semicolon separated list of package names to be excluded from the analysis. Regex expressions are supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
                 "joi": "17.4.0",
                 "spdx-expression-parse": "3.0.1",
                 "spdx-satisfies": "5.0.0",
-                "tslib": "2.1.0"
+                "tslib": "2.1.0",
+                "xmlbuilder": "^15.1.1"
             },
             "bin": {
                 "license-compliance": "bin/cli.js"
@@ -6074,6 +6075,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/xmlbuilder": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
         "node_modules/y18n": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -11086,6 +11095,11 @@
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
             "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
             "dev": true
+        },
+        "xmlbuilder": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
         },
         "y18n": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "spdx-expression-parse": "3.0.1",
         "spdx-satisfies": "5.0.0",
         "tslib": "2.1.0",
-        "xmlbuilder": "^15.1.1"
+        "xmlbuilder": "15.1.1"
     },
     "description": "License compliance checker",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "joi": "17.4.0",
         "spdx-expression-parse": "3.0.1",
         "spdx-satisfies": "5.0.0",
-        "tslib": "2.1.0"
+        "tslib": "2.1.0",
+        "xmlbuilder": "^15.1.1"
     },
     "description": "License compliance checker",
     "devDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -51,7 +51,7 @@ export async function getConfiguration(): Promise<Configuration | null> {
         development: joi.boolean(),
         direct: joi.boolean(),
         exclude: joi.array(),
-        format: joi.string().valid(Formatter.csv, Formatter.json, Formatter.text),
+        format: joi.string().valid(Formatter.csv, Formatter.json, Formatter.text, Formatter.xunit),
         production: joi.boolean(),
         report: joi.string().valid(Report.detailed, Report.summary),
     }).validate(configuration);

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -1,7 +1,8 @@
 export enum Formatter {
     csv = "Csv",
     json = "Json",
-    text = "Text"
+    text = "Text",
+    xunit = "Xunit"
 }
 
 export enum LicenseStatus {

--- a/src/formatters/factory.ts
+++ b/src/formatters/factory.ts
@@ -2,11 +2,12 @@ import { Formatter } from "./index";
 import { Csv } from "./csv";
 import { Json } from "./json";
 import { Text } from "./text";
+import { Xunit } from "./xunit";
 import { Formatter as FormatterName } from "../enumerations";
 
 export class Factory {
     static getInstance(format: FormatterName): Formatter {
-        const classes = { Csv, Json, Text };
+        const classes = { Csv, Json, Text, Xunit };
         return new classes[format]();
     }
 }

--- a/src/formatters/xunit.ts
+++ b/src/formatters/xunit.ts
@@ -1,0 +1,146 @@
+import xmlbuilder from "xmlbuilder";
+
+import { Formatter } from "./index";
+import { Package } from "../interfaces";
+
+interface LicenseDetail {
+    name: string;
+    packages: Array<Package>;
+}
+
+type XmlValue = string | number | boolean;
+
+type RecursiveXmlValue = XmlValue | Record<string, XmlValue> | Array<Record<string, XmlValue>>;
+
+interface XUnitTestCase extends Record<string, RecursiveXmlValue> {
+    failure: Record<string, XmlValue>;
+}
+
+interface XUnitTestSuite extends Record<string, RecursiveXmlValue | Array<XUnitTestCase>> {
+    testcase: Array<XUnitTestCase>;
+}
+
+interface XUnitTestSuites extends Record<string, RecursiveXmlValue | Array<XUnitTestSuite>> {
+    testsuite: Array<XUnitTestSuite>;
+}
+
+/**
+ * This formatter produces an XUnit compatible format used by some CI/CD engines such as Bitbucket Pipelines
+ * @see https://support.atlassian.com/bitbucket-cloud/docs/test-reporting-in-pipelines/
+ */
+export class Xunit implements Formatter {
+    private readonly TEST_SUITES_NAME = "License Compliance";
+    private readonly TEST_CASE_ERROR_TYPE = "License Compliance Error";
+
+    detail(packages: Array<Package>): void {
+        const xmlContent = this.serializeObjectToXml({
+            testsuites: this.formatDetailedTestSuites(packages),
+        });
+
+        console.info(xmlContent);
+    }
+
+    summary(licenses: Array<{ name: string; count: number }>): void {
+        const xmlContent = this.serializeObjectToXml({
+            testsuites: this.formatSummaryTestSuites(licenses),
+        });
+
+        console.info(xmlContent);
+    }
+
+    private formatDetailedTestSuites(packages: Array<Package>): XUnitTestSuites {
+        const detailedList = this.groupPackagesByLicense(packages);
+        const totalNumberOfFailures = detailedList.reduce((sum, license) => sum + license.packages.length, 0);
+
+        return {
+            "@name": this.TEST_SUITES_NAME,
+            "@tests": totalNumberOfFailures,
+            "@errors": 0,
+            "@failures": totalNumberOfFailures,
+            testsuite: detailedList.map((license) => ({
+                "@name": license.name,
+                "@tests": license.packages.length,
+                "@errors": 0,
+                "@failures": license.packages.length,
+                testcase: license.packages.map((packageInformations) => ({
+                    "@name": `${packageInformations.name}@${packageInformations.version}`,
+                    "@path": packageInformations.path,
+                    failure: {
+                        "@type": this.TEST_CASE_ERROR_TYPE,
+                        "#text": `Package "${packageInformations.name}@${packageInformations.version}" uses non compliant license "${packageInformations.license}"`,
+                    },
+                })),
+            })),
+        };
+    }
+
+    private formatSummaryTestSuites(licenses: Array<{ name: string; count: number }>): XUnitTestSuites {
+        return {
+            "@name": this.TEST_SUITES_NAME,
+            "@tests": licenses.length,
+            "@errors": 0,
+            "@failures": licenses.length,
+            testsuite: licenses.map((license) => ({
+                "@name": license.name,
+                "@tests": 1,
+                "@errors": 0,
+                "@failures": 1,
+                testcase: [{
+                    "@name": license.name,
+                    failure: {
+                        "@type": this.TEST_CASE_ERROR_TYPE,
+                        "#text": `${license.count} package${license.count > 1 ? "s" : ""} use non compliant license "${license.name}"`,
+                    },
+                }],
+            })),
+        };
+    }
+
+    /**
+     * Loop through a list of packages and group them by license name
+     */
+    private groupPackagesByLicense(packages: Array<Package>): Array<LicenseDetail> {
+        return packages.reduce<Array<LicenseDetail>>(
+            (licenses, packageInformations) => {
+                const licenseIndex = licenses.findIndex((license) => license.name === packageInformations.license);
+
+                if (licenseIndex >= 0) {
+                    // if the license was already in the iterator, push the current package to its list
+                    licenses[licenseIndex].packages.push(packageInformations);
+                } else {
+                    // otherwise add an item with the license name
+                    licenses.push({
+                        name: packageInformations.license,
+                        packages: [packageInformations],
+                    });
+                }
+
+                return licenses;
+            },
+            [],
+        );
+    }
+
+    private serializeObjectToXml(object: Record<string, RecursiveXmlValue | XUnitTestSuites>): string {
+        return xmlbuilder
+            .create(object, {
+                stringify: {
+                    attEscape: this.escapeString,
+                    textEscape: this.escapeString,
+                },
+            })
+            .dec("1.0", "UTF-8")
+            .end({
+                pretty: true,
+            });
+    }
+
+    private escapeString(text: string): string {
+        return text
+            .replace(/&/g, "&amp;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&apos;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+}

--- a/tests/formatters/factory.spec.ts
+++ b/tests/formatters/factory.spec.ts
@@ -5,6 +5,7 @@ import { Csv } from "../../src/formatters/csv";
 import { Factory } from "../../src/formatters/factory";
 import { Json } from "../../src/formatters/json";
 import { Text } from "../../src/formatters/text";
+import { Xunit } from "../../src/formatters/xunit";
 
 test("Csv", (t) => {
     const formatter = Factory.getInstance(Formatter.csv);
@@ -22,4 +23,10 @@ test("Text", (t) => {
     const formatter = Factory.getInstance(Formatter.text);
 
     t.true(formatter instanceof Text);
+});
+
+test("Xunit", (t) => {
+    const formatter = Factory.getInstance(Formatter.xunit);
+
+    t.true(formatter instanceof Xunit);
 });

--- a/tests/formatters/xunit.spec.ts
+++ b/tests/formatters/xunit.spec.ts
@@ -1,0 +1,67 @@
+import test, { afterEach, beforeEach } from "ava";
+import * as sinon from "sinon";
+
+import { Xunit } from "../../src/formatters/xunit";
+import { Package } from "../../src/interfaces";
+
+let stubConsole: sinon.SinonStub;
+
+beforeEach(() => {
+    stubConsole = sinon.stub(console, "info");
+});
+
+afterEach(() => {
+    sinon.restore();
+});
+
+test.serial("Detailed", (t) => {
+    const packages: Array<Package> = [
+        { name: "pack-01", path: "pack-01", version: "1.1.0", license: "MIT", repository: "company/project" },
+        { name: "pack-02", path: "pack-02", version: "2.2.0", license: "MIT", repository: "company/project2" },
+        { name: "pack-03", path: "pack-03", version: "0.0.3", license: "Unknown", repository: "company/project-3" },
+    ];
+
+    const xunit = new Xunit();
+    xunit.detail(packages);
+
+    t.true(stubConsole.calledWithExactly(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="License Compliance" tests="3" errors="0" failures="3">
+  <testsuite name="MIT" tests="2" errors="0" failures="2">
+    <testcase name="pack-01@1.1.0" path="pack-01">
+      <failure type="License Compliance Error">Package &quot;pack-01@1.1.0&quot; uses non compliant license &quot;MIT&quot;</failure>
+    </testcase>
+    <testcase name="pack-02@2.2.0" path="pack-02">
+      <failure type="License Compliance Error">Package &quot;pack-02@2.2.0&quot; uses non compliant license &quot;MIT&quot;</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="Unknown" tests="1" errors="0" failures="1">
+    <testcase name="pack-03@0.0.3" path="pack-03">
+      <failure type="License Compliance Error">Package &quot;pack-03@0.0.3&quot; uses non compliant license &quot;Unknown&quot;</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`));
+});
+
+test.serial("Summary", (t) => {
+    const licenses: Array<{ name: string; count: number }> = [
+        { name: "MIT", count: 9 },
+        { name: "Apache-2.0", count: 1 },
+    ];
+
+    const xunit = new Xunit();
+    xunit.summary(licenses);
+
+    t.true(stubConsole.calledWithExactly(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="License Compliance" tests="2" errors="0" failures="2">
+  <testsuite name="MIT" tests="1" errors="0" failures="1">
+    <testcase name="MIT">
+      <failure type="License Compliance Error">9 packages use non compliant license &quot;MIT&quot;</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="Apache-2.0" tests="1" errors="0" failures="1">
+    <testcase name="Apache-2.0">
+      <failure type="License Compliance Error">1 package use non compliant license &quot;Apache-2.0&quot;</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`));
+});


### PR DESCRIPTION
- feat(formatters): add new xunit formatter
  - add new Xunit formatter (using xmlbuilder internally) with summary and detailed test suites
  - add unit tests for xunit formatter covering all reporters
  - allow "xunit" formatter in configuration validation
- docs(README): add xunit to --format list

Resolves #70 