### PR TITLE
Bugfix: prevent false negative reports

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -62,3 +62,7 @@ export async function getConfiguration(): Promise<Configuration | null> {
 
     return configuration;
 }
+
+export function isComplianceModeEnabled(configuration: Pick<Configuration, "allow">): boolean {
+    return Array.isArray(configuration.allow) && configuration.allow.length > 0;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import Debug from "debug";
 
-import { getConfiguration } from "./configuration";
+import { getConfiguration, isComplianceModeEnabled } from "./configuration";
 import { excludePackages } from "./filters";
 import { onlyAllow } from "./license";
 import { getInstalledPackages } from "./npm";
@@ -29,8 +29,7 @@ export async function main(): Promise<boolean> {
     const report = FactoryReport.getInstance(configuration.report, configuration.format);
 
     // Verify allowed licenses: command behaviour will be different whether "allow" is set or not
-    const isComplianceModeEnabled = Array.isArray(configuration.allow) && configuration.allow.length > 0;
-    if (isComplianceModeEnabled) {
+    if (isComplianceModeEnabled(configuration)) {
         // Running compliance checkup: identify non compliant packages
         const invalidPackages = onlyAllow(packages, configuration);
         if (invalidPackages.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,9 +40,9 @@ export async function main(): Promise<boolean> {
 
         // All packages are compliant: return with success code
         return true;
-    } else {
-        // Inspecting packages: process the list & return with success code
-        report.process(packages);
-        return true;
     }
+
+    // Running license inspection: process the list & return with success code
+    report.process(packages);
+    return true;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,8 @@ export async function main(): Promise<boolean> {
     // Get all installed packages
     let packages = await getInstalledPackages(configuration);
     if (packages.length === 0) {
-        return false;
+        // no dependency -> no compliance issue
+        return true;
     }
 
     // Filter packages

--- a/tests/configuration/isComplianceModeEnabled.spec.ts
+++ b/tests/configuration/isComplianceModeEnabled.spec.ts
@@ -1,0 +1,19 @@
+import test from "ava";
+
+import { isComplianceModeEnabled } from "../../src/configuration";
+
+test.serial("Running compliance checkup when allow is set", async (t) => {
+    const complianceMode = isComplianceModeEnabled({
+        allow: ["MIT"],
+    });
+
+    t.true(complianceMode);
+});
+
+test.serial("Running license inspection otherwise", (t) => {
+    const complianceMode = isComplianceModeEnabled({
+        allow: [],
+    });
+
+    t.false(complianceMode);
+});

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -35,7 +35,7 @@ test.serial("No packages installed", async (t) => {
 
     const r = await main();
 
-    t.false(r);
+    t.true(r);
 });
 
 test.serial("Not allowed licenses", async (t) => {


### PR DESCRIPTION
- fix(main): return "true" when 0 dependency is found
  - there is no compliance issue: ensure the exit code is 0 (success)
- feat(compliance-mode): improve compliance checkup report
  - set return value based on invalid packages length (if allow is set)
  - only process invalid packages (if allow is set)

Resolves #85