### PR TITLE
feat: support an arbitrary filter function for `exclude`

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,26 +1,18 @@
-import { Configuration, Package } from "./interfaces";
+import { Configuration, Package, PackageFilter } from "./interfaces";
 
 export function excludePackages(
     packages: Array<Package>,
     configuration: Pick<Configuration, "exclude">,
 ): Array<Package> {
-    const { exclude: excludeFilters } = configuration;
-    if (excludeFilters.length === 0) {
-        return packages;
-    }
+    const { exclude: excludeFilter } = configuration;
+    return excludeFilter ? packages.filter((pkg): boolean => !excludeFilter(pkg)) : packages;
+}
 
-    return packages.filter((pack): boolean => {
-        for (const filter of excludeFilters) {
-            if (typeof filter === "string") {
-                if (pack.name === filter) {
-                    return false;
-                }
-            } else if (filter.test(pack.name)) {
-                return false;
-            }
-        }
-        return true;
-    });
+export function parseExclude(exclude: Array<string | RegExp>): PackageFilter {
+    return (pack: Package): boolean =>
+        exclude.some((filter): boolean => {
+            return typeof filter === "string" ? pack.name === filter : filter.test(pack.name);
+        });
 }
 
 export function queryPackages(packages: Array<Package>, configuration: Pick<Configuration, "query">): Array<Package> {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,17 +1,30 @@
 import { Formatter, LicenseStatus, Report } from "./enumerations";
 
-export interface Configuration {
+export type PackageFilter = (pkg: Package) => boolean;
+
+export interface RawConfiguration {
     allow: Array<string>;
     development: boolean;
     direct: boolean;
-    exclude: Array<string | RegExp>;
+    exclude: PackageFilter | Array<string | RegExp>;
     format: Formatter;
     production: boolean;
     query: Array<string>;
     report: Report;
 }
 
-export interface ExtendableConfiguration extends Partial<Configuration> {
+export interface Configuration {
+    allow: Array<string>;
+    development: boolean;
+    direct: boolean;
+    exclude?: PackageFilter;
+    format: Formatter;
+    production: boolean;
+    query: Array<string>;
+    report: Report;
+}
+
+export interface ExtendableConfiguration extends Partial<RawConfiguration> {
     extends?: string;
 }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -38,11 +38,13 @@ export function processArgs(): Configuration {
 
     verifyIncompatibleArguments();
 
-    const rawConfiguration = program.opts();
-    return <Configuration>{
-        ...rawConfiguration,
-        exclude: rawConfiguration.exclude ? parseExclude(rawConfiguration.exclude) : undefined,
-    };
+    const { exclude, ...rawConfiguration } = program.opts();
+    return exclude
+        ? <Configuration>{
+              ...rawConfiguration,
+              exclude: parseExclude(exclude),
+          }
+        : <Configuration>rawConfiguration;
 }
 
 function help(errorMessage: string): void {

--- a/src/program.ts
+++ b/src/program.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import commander from "commander";
 
 import { Formatter, Report } from "./enumerations";
+import { parseExclude } from "./filters";
 import { Configuration } from "./interfaces";
 import { isLicenseValid } from "./license";
 
@@ -37,7 +38,11 @@ export function processArgs(): Configuration {
 
     verifyIncompatibleArguments();
 
-    return program.opts();
+    const rawConfiguration = program.opts();
+    return <Configuration>{
+        ...rawConfiguration,
+        exclude: rawConfiguration.exclude ? parseExclude(rawConfiguration.exclude) : undefined,
+    };
 }
 
 function help(errorMessage: string): void {

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -49,7 +49,7 @@ test.serial("Default configuration", async (t): Promise<void> => {
     t.is(config?.allow.length, 0);
     t.false(config?.development);
     t.false(config?.direct);
-    t.is(config?.exclude.length, 0);
+    t.is(config?.exclude, undefined);
     t.false(config?.production);
     t.is(config?.format, Formatter.text);
     t.is(config?.report, Report.summary);
@@ -106,7 +106,7 @@ test.serial("Inline configuration, not extended", async (t): Promise<void> => {
     t.is(config?.allow[1], "ISC");
     t.false(config?.development);
     t.false(config?.direct);
-    t.is(config?.exclude.length, 0);
+    t.is(config?.exclude, undefined);
     t.true(config?.production);
     t.is(config?.format, Formatter.json);
     t.is(config?.report, Report.summary);
@@ -163,7 +163,7 @@ test.serial("Inline configuration, extended null", async (t): Promise<void> => {
     t.is(config?.allow[0], "Apache-2.0");
     t.false(config?.development);
     t.false(config?.direct);
-    t.is(config?.exclude.length, 0);
+    t.is(config?.exclude, undefined);
     t.false(config?.production);
     t.is(config?.format, Formatter.text);
     t.is(config?.report, Report.detailed);
@@ -207,7 +207,7 @@ test.serial("Inline configuration, extended", async (t): Promise<void> => {
     t.is(config?.allow[0], "Apache-2.0");
     t.false(config?.development);
     t.true(config?.direct);
-    t.is(config?.exclude.length, 0);
+    t.is(config?.exclude, undefined);
     t.true(config?.production);
     t.is(config?.format, Formatter.json);
     t.is(config?.report, Report.detailed);

--- a/tests/filters/excludePackages.spec.ts
+++ b/tests/filters/excludePackages.spec.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import * as sinon from "sinon";
 
-import { excludePackages } from "../../src/filters";
+import { excludePackages, parseExclude } from "../../src/filters";
 import { Package } from "../../src/interfaces";
 
 test.after((): void => {
@@ -12,7 +12,7 @@ test("No filters", (t): void => {
     const packages = getPackages();
 
     // Arguments
-    const filtered = excludePackages(packages, { exclude: [] });
+    const filtered = excludePackages(packages, { exclude: parseExclude([]) });
 
     t.is(filtered.length, 5);
 });
@@ -21,7 +21,7 @@ test("By package names", (t): void => {
     const packages = getPackages();
 
     // Arguments
-    const filtered = excludePackages(packages, { exclude: ["test-01", "@company/test-02"] });
+    const filtered = excludePackages(packages, { exclude: parseExclude(["test-01", "@company/test-02"]) });
 
     t.is(filtered.length, 3);
     t.is(filtered[0].name, "@company/test-01");
@@ -33,7 +33,7 @@ test("Regex", (t): void => {
     const packages = getPackages();
 
     // Arguments
-    const filtered = excludePackages(packages, { exclude: [/^@company/] });
+    const filtered = excludePackages(packages, { exclude: parseExclude([/^@company/]) });
 
     t.is(filtered.length, 3);
     t.is(filtered[0].name, "test-01");
@@ -45,11 +45,20 @@ test("Regex and string", (t): void => {
     const packages = getPackages();
 
     // Arguments
-    const filtered = excludePackages(packages, { exclude: [/^@company/, "test-02"] });
+    const filtered = excludePackages(packages, { exclude: parseExclude([/^@company/, "test-02"]) });
 
-    t.is(filtered.length, 2);
     t.is(filtered[0].name, "test-01");
     t.is(filtered[1].name, "test-03");
+});
+
+test("Filter function", (t): void => {
+    const packages = getPackages();
+
+    // Arguments
+    const filtered = packages.filter((pkg: Package): boolean => pkg.name === "test-02");
+
+    t.is(filtered.length, 1);
+    t.is(filtered[0].name, "test-02");
 });
 
 function getPackages(): Array<Package> {

--- a/tests/program/processArgs.spec.ts
+++ b/tests/program/processArgs.spec.ts
@@ -1,6 +1,7 @@
 import test from "ava";
 import * as sinon from "sinon";
 
+import { Package, PackageFilter } from "interfaces";
 import { Formatter, Report } from "../../src/enumerations";
 import { processArgs } from "../../src/program";
 
@@ -80,11 +81,12 @@ test("Exclude", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--exclude", "pack-01;/^@company/;pack-02"]);
 
     const configuration = processArgs();
+    const exclude = <PackageFilter>configuration.exclude;
 
-    t.is(configuration.exclude.length, 3);
-    t.is(configuration.exclude[0], "pack-01");
-    t.deepEqual(configuration.exclude[1], /^@company/);
-    t.is(configuration.exclude[2], "pack-02");
+    t.is(exclude(<Package>{ name: "@company/blah" }), true);
+    t.is(exclude(<Package>{ name: "pack-01" }), true);
+    t.is(exclude(<Package>{ name: "pack-02" }), true);
+    t.is(exclude(<Package>{ name: "pack-03" }), false);
 });
 
 test("Format", (t): void => {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -12,7 +12,7 @@ export function getDefaultConfiguration(): Configuration {
         allow: [],
         development: false,
         direct: false,
-        exclude: [],
+        exclude: undefined,
         production: false,
         format: Formatter.text,
         query: [],


### PR DESCRIPTION
closes https://github.com/tmorell/license-compliance/issues/215

-   support an arbitrary filter function for `exclude`
-   normalize CLI and rc-file args to the filter function for backwards compat

lmk if this approach makes sense! (review commit by commit for clarity)