### PR TITLE
feat: validate 'allow'

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,7 @@ import path from "path";
 
 import { Formatter, Report } from "./enumerations";
 import { Configuration, ExtendableConfiguration } from "./interfaces";
+import { isLicenseValid } from "./license";
 import { processArgs } from "./program";
 import { toPascal } from "./util";
 
@@ -48,7 +49,18 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     // Validate configuration
     const result = joi
         .object({
-            allow: joi.array().items(joi.string()),
+            allow: joi
+                .array()
+                .items(joi.string())
+                .custom((licenses): boolean => {
+                    for (const license of licenses) {
+                        if (!isLicenseValid(license)) {
+                            throw new Error(`Invalid SDPX license identifier in "allow": "${license}"`);
+                        }
+                    }
+
+                    return true;
+                }),
             development: joi.boolean(),
             direct: joi.boolean(),
             exclude: joi.array(),

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -213,6 +213,32 @@ test.serial("Inline configuration, extended", async (t): Promise<void> => {
     t.is(config?.report, Report.detailed);
 });
 
+test.serial("Validates 'allow'", async (t): Promise<void> => {
+    // Inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["Invalid SPDX"],
+                report: Report.detailed.toLowerCase(),
+                extends: "@acme/license-policy",
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+    sinon.stub(explorer, "load").returns(Promise.resolve(null));
+
+    // No command line args
+    sinon.stub(program, "processArgs").returns(<Configuration>{});
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.is(config, null);
+});
+
 function createExplorer(): Explorer {
     return {
         search: (): Promise<CosmiconfigResult> => Promise.resolve(null),


### PR DESCRIPTION
this prevents more mysterious behavior/errors downstream, like when spdxSatisifies fails because it's using "(MIT OR SomeInvalidLicense)" on the left hand side of the expression

- breaking test for invalid SPDX identifier in "allow"
- validate 'allow' using spdx-expression-parse