### PR TITLE
Fix getNodeModulesPath dir separator on Windows

### DIFF
--- a/src/node-modules.ts
+++ b/src/node-modules.ts
@@ -10,7 +10,7 @@ import path from "path";
  */
 export function getNodeModulesPath(workingDir = process.cwd()): string | null {
     const NODE_MODULES = "node_modules";
-    const segments = workingDir.split("/");
+    const segments = workingDir.split(path.sep);
     segments[0] = "/";
     for (let i = segments.length; i >= 1; i--) {
         const searchPath = path.join(...segments.slice(0, i), NODE_MODULES);


### PR DESCRIPTION
Since version 3.0.0 the license compliance CLI fails on Windows due to the wrong separator char being used.