### PR TITLE
fix: resolving packages in monorepos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "cosmiconfig": "9.0.0",
                 "debug": "4.3.4",
                 "joi": "17.12.3",
+                "resolve-package-path": "^4.0.3",
                 "spdx-expression-parse": "4.0.0",
                 "spdx-satisfies": "5.0.1",
                 "tslib": "2.6.2",
@@ -47,7 +48,7 @@
                 "typescript": "5.4.4"
             },
             "engines": {
-                "node": ">=14.17.0"
+                "node": ">=18.20.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -6140,6 +6141,25 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
+        "node_modules/path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+            "dependencies": {
+                "path-root-regex": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/path-to-regexp": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
@@ -6642,6 +6662,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/resolve-package-path": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+            "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+            "dependencies": {
+                "path-root": "^0.1.1"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "cosmiconfig": "9.0.0",
         "debug": "4.3.4",
         "joi": "17.12.3",
+        "resolve-package-path": "^4.0.3",
         "spdx-expression-parse": "4.0.0",
         "spdx-satisfies": "5.0.1",
         "tslib": "2.6.2",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -2,11 +2,11 @@ import chalk from "chalk";
 import Debug from "debug";
 import path from "path";
 
+import resolvePackagePath from "resolve-package-path";
 import { Configuration, Package } from "./interfaces";
 import { getLicense } from "./license";
 import { getRepository } from "./repository";
 import * as util from "./util";
-import resolvePackagePath from "resolve-package-path";
 
 const debug = Debug("license-compliance:npm");
 const PACKAGE_JSON = "package.json";
@@ -68,12 +68,9 @@ function alreadyAnalyzed(packages: Array<Package>, pack: Package): boolean {
  *
  * @param {string} packageName Name of the package.
  * @param {(string | undefined)} parentNodeModulesPath Path of the parent package.
- * @returns {(string | undefined>)} Path where the package was found; undefined if not found.
+ * @returns {(string | null>)} Path where the package was found; null if not found.
  */
-function getInstalledPath(
-    packageName: string,
-    parentNodeModulesPath: string,
-): string | null {
+function getInstalledPath(packageName: string, parentNodeModulesPath: string): string | null {
     const resolved = resolvePackagePath(packageName, parentNodeModulesPath);
     if (resolved) {
         return path.dirname(resolved);

--- a/tests/npm/getInstalledPackages.spec.ts
+++ b/tests/npm/getInstalledPackages.spec.ts
@@ -29,7 +29,9 @@ test.serial("Get packages, empty package.json", async (t): Promise<void> => {
     const packages = await getInstalledPackages(
         getDefaultConfiguration(),
         path.join(__dirname, "..", "mock-packages", "installation-empty"),
+        path.join(__dirname, "..", "mock-packages", "installation-empty"),
     );
+
     t.is(packages.length, 0);
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
+        "skipLibCheck": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "outDir": "lib",


### PR DESCRIPTION
Use `resolve-package-path` to resolve installed package paths to be used in monorepos

`require.resolve` doesn't work reliably. If used directly with the package name, it fails for packages that don't have a `main` entry (and also returns the path to main entry instead of the pkg dir). If used with `<package-name>/package.json`, it fails for ES modules that don't define `package.json` under `exports`. `resolve-package-path` simply takes a package name and returns the path to its `package.json` in every case.