### PR TITLE
refactor: commander option parsing

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,8 +31,16 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         }
     }
 
+    // Get args configuration
+    let config: Configuration;
+    try {
+        config = processArgs();
+    } catch {
+        return null;
+    }
+
     // Merge configurations: CLI > inline > extended
-    const mergedConfiguration = Object.assign(configExtended, <Partial<Configuration>>configInline, processArgs());
+    const mergedConfiguration = Object.assign(configExtended, <Partial<Configuration>>configInline, config);
     const configuration = {
         allow: mergedConfiguration.allow || [],
         development: !!mergedConfiguration.development || false,

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import commander from "commander";
 
 import { Formatter, Report } from "./enumerations";
@@ -10,54 +9,65 @@ let program: commander.Command;
 export function processArgs(): Configuration {
     program = new commander.Command();
     program
-        .exitOverride((): void => process.exit(1))
+        .exitOverride()
         .name("license-compliance")
         .description("Analyzes licenses of installed NPM packages, assisting with compliance.")
         .option("-p, --production", "Analyzes only production dependencies.")
-        .option("-d, --development", "Analyzes only development dependencies.")
-        .option("-t, --direct", "Analyzes only direct dependencies (depth = 1).")
-        .option("-f, --format <format>", "Report format, csv, text, or json (default = text).", verifyFormat)
-        .option("-r, --report <report>", "Report type, summary or detailed (default = summary).", verifyReport)
-        .option<Array<string>>(
-            "-q, --query <licenses>",
-            "Semicolon separated list of licenses to query. Must conform to SPDX specifications.",
-            verifyLicense("query"),
+        .addOption(
+            new commander.Option("-d, --development", "Analyzes only development dependencies.").conflicts(
+                "production",
+            ),
         )
-        .option<Array<string>>(
-            "-a, --allow <licenses>",
-            "Semicolon separated list of allowed licenses. Must conform to SPDX specifications.",
-            verifyLicense("allow"),
+        .option("-t, --direct", "Analyzes only direct dependencies (depth = 1).")
+        .addOption(
+            new commander.Option(
+                "-f, --format <format>",
+                "Report format, csv, text, or json (default = text).",
+            ).choices(Object.keys(Formatter)),
+        )
+        .addOption(
+            new commander.Option(
+                "-r, --report <report>",
+                "Report type, summary or detailed (default = summary).",
+            ).choices(Object.keys(Report)),
+        )
+        .addOption(
+            new commander.Option(
+                "-a, --allow <licenses>",
+                "Semicolon separated list of allowed licenses. Must conform to SPDX specifications.",
+            )
+                .conflicts("query")
+                .argParser(verifyLicense),
+        )
+        .addOption(
+            new commander.Option(
+                "-q, --query <licenses>",
+                "Semicolon separated list of licenses to query. Must conform to SPDX specifications.",
+            )
+                .conflicts("allow")
+                .argParser(verifyLicense),
         )
         .option<Array<string | RegExp>>(
             "-e, --exclude <packages>",
             "Semicolon separated list of packages to be excluded from analysis. Regex expressions are supported.",
             verifyExclude,
         )
-        .parse(process.argv);
-
-    verifyIncompatibleArguments();
+        .parse();
 
     return program.opts();
 }
 
-function help(errorMessage: string): void {
-    console.error(chalk.red("Error:"), errorMessage);
-    console.info(program.help());
-}
-
-function verifyLicense(arg: string): (value: string) => Array<string> {
-    return (value: string): Array<string> => {
-        return value
-            .split(";")
-            .map((license): string => license.trim())
-            .filter((license): boolean => !!license)
-            .map((license): string => {
-                if (!isLicenseValid(license) && license !== "UNKNOWN") {
-                    help(`Invalid --${arg} option "${license}"`);
-                }
-                return license;
-            });
-    };
+function verifyLicense(value: string): Array<string> {
+    return value
+        .split(";")
+        .map((license): string => license.trim())
+        .filter((license): boolean => !!license)
+        .map((license): string => {
+            if (!isLicenseValid(license) && license !== "UNKNOWN") {
+                throw new commander.InvalidArgumentError("Licenses must adhere to the SPDX specification.");
+            }
+            return license;
+        });
 }
 
 function verifyExclude(value: string): Array<string | RegExp> {
@@ -67,32 +77,13 @@ function verifyExclude(value: string): Array<string | RegExp> {
         .filter((exclude): boolean => !!exclude)
         .map((exclude): string | RegExp => {
             if (exclude.startsWith("/") && exclude.endsWith("/")) {
-                return RegExp(exclude.substring(1, exclude.length - 1));
+                const pattern = exclude.substring(1, exclude.length - 1);
+                try {
+                    return new RegExp(pattern);
+                } catch {
+                    throw new commander.InvalidArgumentError("Invalid regular expression pattern.");
+                }
             }
             return exclude;
         });
-}
-
-function verifyFormat(value: string): string {
-    if (!Object.keys(Formatter).includes(value)) {
-        help(`Invalid --format option "${value}"`);
-    }
-    return value;
-}
-
-function verifyReport(value: string): string {
-    if (!Object.keys(Report).includes(value)) {
-        help(`Invalid --report option "${value}"`);
-    }
-    return value;
-}
-
-function verifyIncompatibleArguments(): void {
-    const options = program.opts();
-    if (options.production && options.development) {
-        help('Options "--production" and "--development" cannot be used together');
-    }
-    if (options.query && options.allow) {
-        help("Options '--allow' and '--query' cannot be used together");
-    }
 }

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -34,6 +34,20 @@ test.afterEach((): void => {
     sinon.restore();
 });
 
+test.serial("Command lined args failed", async (t): Promise<void> => {
+    // No inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+
+    // Command line args
+    sinon.stub(program, "processArgs").throws("error");
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.is(config, null);
+});
+
 test.serial("Default configuration", async (t): Promise<void> => {
     // No inline configuration
     const explorer: Explorer = createExplorer();

--- a/tests/program/processArgs.spec.ts
+++ b/tests/program/processArgs.spec.ts
@@ -40,12 +40,12 @@ test("Allow, valid licenses", (t): void => {
 
 test("Allow, invalid licenses", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--allow", "MIT;ISC;Apache 2.0"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.true(error.message.includes("error: option '-a, --allow <licenses>' argument 'MIT;ISC;Apache 2.0' is invalid"));
 });
 
 test("Development", (t): void => {
@@ -103,12 +103,15 @@ test("Format", (t): void => {
 
 test("Format, bad param", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--format", "bad-param"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.is(
+        error?.message,
+        "error: option '-f, --format <format>' argument 'bad-param' is invalid. Allowed choices are csv, json, text, xunit.",
+    );
 });
 
 test("Production", (t): void => {
@@ -127,12 +130,12 @@ test("Production", (t): void => {
 
 test("Production and development", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--production", "--development"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.is(error?.message, "error: option '-d, --development' cannot be used with option '-p, --production'");
 });
 
 test("Query UNKNOWN", (t): void => {
@@ -147,22 +150,22 @@ test("Query UNKNOWN", (t): void => {
 
 test("Query and allow", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--allow", "MIT", "--query", "MIT"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.is(error?.message, "error: option '-a, --allow <licenses>' cannot be used with option '-q, --query <licenses>'");
 });
 
 test("Query, invalid licenses", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--query", "MIT;ISC;Apache 2.0"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.true(error.message.includes("error: option '-q, --query <licenses>' argument 'MIT;ISC;Apache 2.0' is invalid."));
 });
 
 test("Report", (t): void => {
@@ -181,10 +184,26 @@ test("Report", (t): void => {
 
 test("Report, bad param", (t): void => {
     sinon.stub(process, "argv").value(["", "", "--report", "bad-param"]);
-    const stubProcess = sinon.stub(process, "exit");
 
-    processArgs();
+    const error = t.throws((): void => {
+        processArgs();
+    });
 
-    t.true(stubProcess.calledTwice);
-    stubProcess.restore();
+    t.is(
+        error?.message,
+        "error: option '-r, --report <report>' argument 'bad-param' is invalid. Allowed choices are detailed, summary.",
+    );
+});
+
+test("Invalid RegEx", (t): void => {
+    sinon.stub(process, "argv").value(["", "", "--exclude", "/[a-z/"]);
+
+    const error = t.throws((): void => {
+        processArgs();
+    });
+
+    t.is(
+        error?.message,
+        "error: option '-e, --exclude <packages>' argument '/[a-z/' is invalid. Invalid regular expression pattern.",
+    );
 });


### PR DESCRIPTION

## Fixes
- `--help` triggers exitOverride and terminates the CLI with exit code 1 instead of standard exit code 0.

## Improvements
- Switching from `program.exitOverride(() => process.exit(1))` to `program.exitOverride()` lets `commander` throw `CommanderError` instead of forcibly terminating the process inside option parsers. This enables accurate testing without stubbing process.exit.
- Replacing manual array lookups (`verifyFormat` and `verifyReport`) with `.choices(Object.keys(...))` leverages `commander's` native enum validation and automatically includes valid options in CLI `--help` text.
- Validate RegEx expressions.
