### PR TITLE
fix: allow broken by UNKNOWN in options

### DIFF
--- a/src/license.ts
+++ b/src/license.ts
@@ -80,7 +80,8 @@ export function onlyAllow(packages: Array<Package>, configuration: Pick<Configur
     }
 
     const invalidPackages = new Array<Package>();
-    const spdxLicense = argsToSpdxLicense(configuration.allow);
+    const allowedLicenses = configuration.allow.filter((value: string): boolean => value !== Literals.UNKNOWN);
+    const spdxLicense = argsToSpdxLicense(allowedLicenses);
     const allowUnknown = configuration.allow.findIndex((value): boolean => value === Literals.UNKNOWN) >= 0;
     for (const pack of packages) {
         const matches =

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,7 +1,7 @@
 import commander from "commander";
 
 import { version } from "../package.json";
-import { Formatter, Report } from "./enumerations";
+import { Formatter, Literals, Report } from "./enumerations";
 import { Configuration } from "./interfaces";
 import { isLicenseValid } from "./license";
 
@@ -71,7 +71,7 @@ function verifyLicense(value: string): Array<string> {
         .map((license): string => license.trim())
         .filter((license): boolean => !!license)
         .map((license): string => {
-            if (!isLicenseValid(license) && license !== "UNKNOWN") {
+            if (!isLicenseValid(license) && license !== Literals.UNKNOWN) {
                 throw new commander.InvalidArgumentError("Licenses must adhere to the SPDX specification.");
             }
             return license;

--- a/tests/license/onlyAllow.spec.ts
+++ b/tests/license/onlyAllow.spec.ts
@@ -148,6 +148,7 @@ test("Some packages not allowed, OR licenses", (t): void => {
 test("Allow UNKNOWN", (t): void => {
     const packages: Array<Package> = [
         {
+            // Valid: Matches UNKNOWN
             name: "test-01",
             path: "test-01",
             version: "1.0.0",
@@ -155,6 +156,7 @@ test("Allow UNKNOWN", (t): void => {
             repository: "company/project",
         },
         {
+            // Invalid: No match at all
             name: "test-02",
             path: "test-02",
             version: "2.0.0",
@@ -162,10 +164,19 @@ test("Allow UNKNOWN", (t): void => {
             repository: "company/project",
         },
         {
+            // Invalid: License itself is invalid
             name: "test-03",
             path: "test-03",
             version: "1.0.0",
             license: "(UNKNOWN OR MIT)",
+            repository: "company/project",
+        },
+        {
+            // Valid: Matches ISC
+            name: "test-04",
+            path: "test-04",
+            version: "1.0.0",
+            license: "ISC",
             repository: "company/project",
         },
     ];


### PR DESCRIPTION
# Summary

Passing `--allow "MIT;UNKNOWN"` to `satisfies` produces an invalid SPDX expression `(MIT OR UNKNOWN)`.
Filtering `UNKNOWN` before calling `satisfies` produces a valid SPDX expression.
```TypeScript
const allowedLicenses = configuration.allow.filter((value: string): boolean => value !== Literals.UNKNOWN);
```
