### PR TITLE
refactor: incorrect dependency type interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,8 +22,8 @@ export interface License {
 }
 
 export interface NpmPackage {
-    dependencies?: Array<[string, string]>;
-    devDependencies?: Array<[string, string]>;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
     license: string | OldLicenseFormat;
     licenses: Array<OldLicenseFormat>;
     name: string;

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -113,7 +113,7 @@ async function getInstalledPath(
  */
 async function readPackages(
     parentName: string,
-    dependencies: Array<[string, string]>,
+    dependencies: Record<string, string>,
     depth: number,
     parentNodeModulesPath: string,
     configuration: Pick<Configuration, "direct">,


### PR DESCRIPTION
# Description

Incorrect  dependency Type Interface:
```TypeScript
export interface NpmPackage {
    dependencies?: Array<[string, string]>;
    devDependencies?: Array<[string, string]>;
    :
}
```

Instead of:
```TypeScript
export interface NpmPackage {
    dependencies?: Record<string, string>;
    devDependencies?: Record<string, string>;
    :
}
```

Currently working because JSON.parse generates the correct type (a record).
