### PR TITLE
fix: report sort mutates array

### DIFF
--- a/src/reports/detailed.ts
+++ b/src/reports/detailed.ts
@@ -8,12 +8,10 @@ export class Detailed implements Reporter {
     constructor(private readonly formatter: Formatter) {}
 
     process(packages: Array<Package>): void {
-        this.sorted = packages;
-        this.sorted.sort((a, b): number => {
+        this.sorted = packages.toSorted((a, b): number => {
             return a.name > b.name ? 1 : -1;
         });
-
-        this.formatter.detail(packages);
+        this.formatter.detail(this.sorted);
     }
 
     get packages(): Array<Package> {

--- a/src/reports/summary.ts
+++ b/src/reports/summary.ts
@@ -14,7 +14,6 @@ export class Summary implements Reporter {
         this.licenses.sort((a, b): number => {
             return b.count - a.count;
         });
-
         this.formatter.summary(this.licenses);
     }
 

--- a/tests/reports/detailed.spec.ts
+++ b/tests/reports/detailed.spec.ts
@@ -24,9 +24,15 @@ test.serial("Summary", (t): void => {
     report.process(packages);
     const sorted = report.packages;
 
+    // Sorted
     t.is(sorted[0].name, "pack-abc");
     t.is(sorted[1].name, "pack-mno");
     t.is(sorted[2].name, "pack-xyz");
+
+    // Original not mutated
+    t.is(packages[0].name, "pack-mno");
+    t.is(packages[1].name, "pack-abc");
+    t.is(packages[2].name, "pack-xyz");
 });
 
 test.serial("With errors", (t): void => {


### PR DESCRIPTION
# Summary

`reports.detailed.process` mutates the input array.

Currently it does not cause any side effects since is it not used after output.
Correcting to avoid possible future defects.
