### PR TITLE
refactor: migrate promisify

### DIFF
--- a/src/license.ts
+++ b/src/license.ts
@@ -4,6 +4,7 @@
 
 import chalk from "chalk";
 import Debug from "debug";
+import { readdir } from "node:fs/promises";
 import path from "path";
 import parse from "spdx-expression-parse";
 import spdxSatisfies from "spdx-satisfies";
@@ -193,7 +194,7 @@ function getLicenseFromArray(licenses: Array<OldLicenseFormat>): string {
 }
 
 async function getLicensePath(packPath: string): Promise<string | null> {
-    const data = await util.readDir(packPath);
+    const data = await readdir(packPath, "utf8");
     for (const fileName of data) {
         if (fileName.toLowerCase().startsWith(LICENSE_FILE)) {
             return path.join(packPath, fileName);

--- a/src/license.ts
+++ b/src/license.ts
@@ -193,7 +193,7 @@ function getLicenseFromArray(licenses: Array<OldLicenseFormat>): string {
 }
 
 async function getLicensePath(packPath: string): Promise<string | null> {
-    const data = await util.readdir(packPath);
+    const data = await util.readDir(packPath);
     for (const fileName of data) {
         if (fileName.toLowerCase().startsWith(LICENSE_FILE)) {
             return path.join(packPath, fileName);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ const debug = Debug("license-compliance:main");
 
 export async function main(): Promise<boolean> {
     // Get node_modules path
-    const nodeModulesPath = getNodeModulesPath();
+    const nodeModulesPath = await getNodeModulesPath();
     if (!nodeModulesPath) {
         return false;
     }

--- a/src/node-modules.ts
+++ b/src/node-modules.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
-import fs from "fs";
+import fs from "node:fs";
+import { access } from "node:fs/promises";
 import { EOL } from "node:os";
 import path from "path";
 
@@ -8,14 +9,19 @@ import path from "path";
  *
  * @returns The node_modules relative path if found; otherwise, null.
  */
-export function getNodeModulesPath(workingDir = process.cwd()): string | null {
+export async function getNodeModulesPath(workingDir = process.cwd()): Promise<string | null> {
     const NODE_MODULES = "node_modules";
     const segments = workingDir.split(path.sep);
     segments[0] = "/";
     for (let i = segments.length; i >= 1; i--) {
         const searchPath = path.join(...segments.slice(0, i), NODE_MODULES);
-        if (fs.existsSync(searchPath)) {
+        try {
+            // Accepted since it will bubble up to find the NODE_MODULES directory
+            // eslint-disable-next-line no-await-in-loop
+            await access(searchPath, fs.constants.R_OK);
             return searchPath;
+        } catch {
+            // Path does not exist, continue searching up directory tree
         }
     }
     console.error(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import util from "util";
+import { readFile, readdir } from "node:fs/promises";
 
 import { NpmPackage } from "./interfaces";
 
@@ -9,8 +9,8 @@ export function fileExists(filePath: string): Promise<boolean> {
     });
 }
 
-export function readdir(path: string): Promise<Array<string>> {
-    return util.promisify(fs.readdir)(path, "utf8");
+export function readDir(path: string): Promise<Array<string>> {
+    return readdir(path, "utf8");
 }
 
 /**
@@ -23,7 +23,7 @@ export async function readPackageJson(packagePath: string): Promise<NpmPackage |
     if (!(await fileExists(packagePath))) {
         return null;
     }
-    const data = await util.promisify(fs.readFile)(packagePath, "utf8");
+    const data = await readFile(packagePath, "utf8");
     if (data) {
         return JSON.parse(data);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { readFile, readdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 
 import { NpmPackage } from "./interfaces";
 
@@ -7,10 +7,6 @@ export function fileExists(filePath: string): Promise<boolean> {
     return new Promise<boolean>((resolve): void => {
         fs.access(filePath, fs.constants.F_OK, (error): void => (error ? resolve(false) : resolve(true)));
     });
-}
-
-export function readDir(path: string): Promise<Array<string>> {
-    return readdir(path, "utf8");
 }
 
 /**

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -23,13 +23,13 @@ test.afterEach((): void => {
 });
 
 test.serial("node_modules not found", async (t): Promise<void> => {
-    sinon.stub(nodeModules, "getNodeModulesPath").returns(null);
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves(null);
     const r = await main();
     t.false(r);
 });
 
 test.serial("Invalid arguments", async (t): Promise<void> => {
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(configuration, "getConfiguration").returns(Promise.resolve(null));
 
     const r = await main();
@@ -39,7 +39,7 @@ test.serial("Invalid arguments", async (t): Promise<void> => {
 
 test.serial("No packages installed", async (t): Promise<void> => {
     const packages = new Array<Package>();
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(configuration, "getConfiguration").returns(Promise.resolve(getMockConfiguration()));
     sinon.stub(npm, "getInstalledPackages").returns(Promise.resolve(packages)); // No packages were found
 
@@ -58,7 +58,7 @@ test.serial("Get licenses summary", async (t): Promise<void> => {
         repository: "company/project",
     });
 
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(configuration, "getConfiguration").returns(Promise.resolve(getMockConfiguration()));
     sinon.stub(npm, "getInstalledPackages").returns(Promise.resolve(packages));
     sinon.stub(filters, "excludePackages").returns(packages);
@@ -81,7 +81,7 @@ test.serial("Not allowed licenses", async (t): Promise<void> => {
         repository: "company/project",
     });
 
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(configuration, "getConfiguration").returns(
         Promise.resolve(
             getMockConfiguration({
@@ -117,7 +117,7 @@ test.serial("Success", async (t): Promise<void> => {
             }),
         ),
     );
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(npm, "getInstalledPackages").returns(Promise.resolve(packages));
     sinon.stub(filters, "excludePackages").returns(packages);
     sinon.stub(license, "onlyAllow").returns(new Array<Package>());
@@ -143,7 +143,7 @@ test.serial("Success query", async (t): Promise<void> => {
             }),
         ),
     );
-    sinon.stub(nodeModules, "getNodeModulesPath").returns("/");
+    sinon.stub(nodeModules, "getNodeModulesPath").resolves("/");
     sinon.stub(npm, "getInstalledPackages").returns(Promise.resolve(packages));
     sinon.stub(filters, "excludePackages").returns(packages);
     sinon.stub(filters, "queryPackages").returns(new Array<Package>());

--- a/tests/node-modules/getNodeModulesPath.spec.ts
+++ b/tests/node-modules/getNodeModulesPath.spec.ts
@@ -15,27 +15,27 @@ test.after((): void => {
     sinon.restore();
 });
 
-test("Find at cwd", (t): void => {
-    const nodeModulesPath = getNodeModulesPath();
+test("Find at cwd", async (t): Promise<void> => {
+    const nodeModulesPath = await getNodeModulesPath();
     t.is(nodeModulesPath, path.join(process.cwd(), NODE_MODULES));
 });
 
-test("Find cwd down the tree", (t): void => {
+test("Find cwd down the tree", async (t): Promise<void> => {
     // 'node_modules' does not exist at 'array-license-01', found at cwd
     const searchPath = path.join(process.cwd(), "tests", "mock-packages", "array-license-01");
-    const nodeModulesPath = getNodeModulesPath(searchPath);
+    const nodeModulesPath = await getNodeModulesPath(searchPath);
     t.is(nodeModulesPath, path.join(process.cwd(), NODE_MODULES));
 });
 
-test("Find cwd up the tree", (t): void => {
+test("Find cwd up the tree", async (t): Promise<void> => {
     // 'node_modules' found at 'installation-full'
     const searchPath = path.join(process.cwd(), "tests", "mock-packages", "installation-full");
-    const nodeModulesPath = getNodeModulesPath(searchPath);
+    const nodeModulesPath = await getNodeModulesPath(searchPath);
     t.is(nodeModulesPath, path.join(searchPath, NODE_MODULES));
 });
 
-test("Not found", (t): void => {
+test("Not found", async (t): Promise<void> => {
     const searchPath = path.join(path.sep);
-    const nodeModulesPath = getNodeModulesPath(searchPath);
+    const nodeModulesPath = await getNodeModulesPath(searchPath);
     t.is(nodeModulesPath, null);
 });


### PR DESCRIPTION
# Summary

Migrate from legacy `util.promisify(fs.readFile)` and `fs.existsSync` to Node 20+ native promises.
