### PR TITLE
refactor: standardize error messages

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -3,7 +3,7 @@ import { cosmiconfig } from "cosmiconfig";
 import joi from "joi";
 import path from "node:path";
 
-import { EOL } from "os";
+import { EOL } from "node:os";
 import { Formatter, Report } from "./enumerations";
 import { Configuration, ExtendableConfiguration } from "./interfaces";
 import { processArgs } from "./program";

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -86,7 +86,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         })
         .validate(configuration);
     if (result.error) {
-        console.error(chalk.red("Configuration error:"), result.error.message);
+        console.error(chalk.red("Error:"), result.error.message);
         return null;
     }
 

--- a/src/formatters/csv.ts
+++ b/src/formatters/csv.ts
@@ -1,4 +1,4 @@
-import { EOL } from "os";
+import { EOL } from "node:os";
 
 import { Literals } from "../enumerations";
 import { Package } from "../interfaces";

--- a/src/formatters/text.ts
+++ b/src/formatters/text.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { EOL } from "os";
+import { EOL } from "node:os";
 
 import { Literals } from "../enumerations";
 import { Package } from "../interfaces";

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ export async function main(): Promise<boolean> {
         const invalidPackages = onlyAllow(packages, configuration);
         if (invalidPackages.length > 0) {
             // If any non-compliant package is found, process the list and return with error code
-            console.error(chalk.red("Not compliant packages found"));
+            console.error(chalk.red("Error:"), "Not compliant packages found");
             report.process(invalidPackages);
             return false;
         }

--- a/src/node-modules.ts
+++ b/src/node-modules.ts
@@ -25,9 +25,8 @@ export async function getNodeModulesPath(workingDir = process.cwd()): Promise<st
         }
     }
     console.error(
-        chalk.red(
-            `'${NODE_MODULES}' could not be found up the directory tree '${workingDir}'${EOL}Please make sure that the packages are installed.`,
-        ),
+        chalk.red("Error:"),
+        `'${NODE_MODULES}' could not be found up the directory tree '${workingDir}'${EOL}Please make sure that the packages are installed.`,
     );
     return null;
 }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -25,7 +25,7 @@ export async function getInstalledPackages(
     const packages: Array<Package> = new Array<Package>();
     const pack = await util.readPackageJson(path.join(packageJsonPath, PACKAGE_JSON));
     if (!pack) {
-        console.error(chalk.red(`Could not find '${PACKAGE_JSON}' at '${packageJsonPath}'`));
+        console.error(chalk.red("Error:"), `Could not find '${PACKAGE_JSON}' at '${packageJsonPath}'`);
         return new Array<Package>();
     }
 
@@ -152,12 +152,15 @@ async function getPackage(
 ): Promise<void> {
     const packagePath = await getInstalledPath(parentName, dependency, parentNodeModulesPath, rootNodeModulesPath);
     if (packagePath === null) {
-        console.error(chalk.red(`Package "${dependency}" was not found. Confirm that all modules are installed.`));
+        console.error(
+            chalk.red("Error:"),
+            `Package "${dependency}" was not found. Confirm that all modules are installed.`,
+        );
         return;
     }
     const file = await util.readPackageJson(path.join(packagePath, PACKAGE_JSON));
     if (!file) {
-        console.error(chalk.red(`Package "${dependency}" is empty and cannot be analyzed.`));
+        console.error(chalk.red("Error:"), `Package "${dependency}" is empty and cannot be analyzed.`);
         return;
     }
     const license = await getLicense(file, packagePath);

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import commander from "commander";
-import { EOL } from "os";
+import { EOL } from "node:os";
 
 import { version } from "../package.json";
 import { Formatter, Literals, Report } from "./enumerations";

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,4 +1,6 @@
+import chalk from "chalk";
 import commander from "commander";
+import { EOL } from "os";
 
 import { version } from "../package.json";
 import { Formatter, Literals, Report } from "./enumerations";
@@ -60,6 +62,11 @@ export function processArgs(): Configuration {
             "Semicolon separated list of packages to be excluded from analysis. Regex expressions are supported.",
             verifyExclude,
         )
+        .configureOutput({
+            writeErr: (str: string): void => {
+                process.stdout.write(`${chalk.red("Error:")} ${str.substring(7)}`);
+            },
+        })
         .parse();
 
     return program.opts();
@@ -72,7 +79,7 @@ function verifyLicense(value: string): Array<string> {
         .filter((license): boolean => !!license)
         .map((license): string => {
             if (!isLicenseValid(license) && license !== Literals.UNKNOWN) {
-                throw new commander.InvalidArgumentError("Licenses must adhere to the SPDX specification.");
+                throw new commander.InvalidArgumentError(`${EOL}Licenses must adhere to the SPDX specification.`);
             }
             return license;
         });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 


### PR DESCRIPTION
# Summary

Standardize error messages to {red}Errror:{/red} the-error-message

Example:
```TypeScript
console.error(chalk.red("Error:"), `Package "${dependency}" is empty and cannot be analyzed.`);
```