### PR TITLE
perf: summary from O(n^2) to O(n)

### DIFF
--- a/src/reports/detailed.ts
+++ b/src/reports/detailed.ts
@@ -8,9 +8,7 @@ export class Detailed implements Reporter {
     constructor(private readonly formatter: Formatter) {}
 
     process(packages: Array<Package>): void {
-        this.sorted = packages.toSorted((a, b): number => {
-            return a.name > b.name ? 1 : -1;
-        });
+        this.sorted = packages.toSorted((a, b): number => a.name.localeCompare(b.name));
         this.formatter.detail(this.sorted);
     }
 

--- a/src/reports/summary.ts
+++ b/src/reports/summary.ts
@@ -3,34 +3,25 @@ import { Package } from "../interfaces";
 import { Reporter } from "./reporter";
 
 export class Summary implements Reporter {
-    private readonly licenses = new Array<{ name: string; count: number }>();
+    private licenses = new Array<{ name: string; count: number }>();
 
     constructor(private readonly formatter: Formatter) {}
 
     process(packages: Array<Package>): void {
+        const lic = new Map<string, number>();
         for (const pack of packages) {
-            this.increase(pack.license);
+            lic.set(pack.license, (lic.get(pack.license) || 0) + 1);
         }
-        this.licenses.sort((a, b): number => {
-            return b.count - a.count;
-        });
+
+        this.licenses = Array.from(lic, ([name, count]): { name: string; count: number } => ({
+            name,
+            count,
+        })).sort((a, b): number => a.name.localeCompare(b.name));
+
         this.formatter.summary(this.licenses);
     }
 
     get summary(): Array<{ name: string; count: number }> {
         return this.licenses;
-    }
-
-    private increase(name: string): void {
-        for (const license of this.licenses) {
-            if (license.name === name) {
-                license.count += 1;
-                return;
-            }
-        }
-        this.licenses.push({
-            name,
-            count: 1,
-        });
     }
 }

--- a/tests/reports/summary.spec.ts
+++ b/tests/reports/summary.spec.ts
@@ -29,12 +29,12 @@ test.serial("Summary", (t): void => {
     report.process(packages);
     const licenses = report.summary;
 
-    t.is(licenses[0].name, "MIT");
-    t.is(licenses[0].count, 5);
+    t.is(licenses[0].name, "Apache-2.0");
+    t.is(licenses[0].count, 1);
     t.is(licenses[1].name, "ISC");
     t.is(licenses[1].count, 2);
-    t.is(licenses[2].name, "Apache-2.0");
-    t.is(licenses[2].count, 1);
+    t.is(licenses[2].name, "MIT");
+    t.is(licenses[2].count, 5);
 });
 
 test.serial("With errors", (t): void => {
@@ -47,8 +47,8 @@ test.serial("With errors", (t): void => {
     report.process(packages);
     const licenses = report.summary;
 
-    t.is(licenses[0].name, "MIT");
+    t.is(licenses[0].name, "ISC");
     t.is(licenses[0].count, 1);
-    t.is(licenses[1].name, "ISC");
+    t.is(licenses[1].name, "MIT");
     t.is(licenses[1].count, 1);
 });


### PR DESCRIPTION
# Summary

Current implementation of `reports/summary` uses O(n^2) to group and count licenses.
Reduce to O(n) by using `Map`.

# Additional Changes
* Change ordering from `count` to `name` using `localeCompare`.
* Update `detailed` to use `localeCompare`.
