### PR TITLE
fix: validate extended configuration

### DIFF
--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -3,7 +3,7 @@ export default {
     development: true,
     direct: true,
     exclude: [/^spdx/, "yaml"],
-    // extends: "@acme/license-policy",
+    // extends: "@tmorell/license-policy",
     format: "text",
     production: true,
     report: "summary",

--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -1,6 +1,6 @@
 export default {
     allow: ["MIT", "0BSD", "BSD-3-Clause"],
-    development: false,
+    development: true,
     direct: true,
     exclude: [/^spdx/, "yaml"],
     // extends: "@acme/license-policy",

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ export default {
 
 > `extends` must reference a package within the project's `node_modules` folder, preventing path traversal.
 
-> The configuration file `.license-compliancerc.js` can also include other properties besides `extends`, allowing you to override the settings from the installed shared package. The command line in the CI will override any configuration; `CLI` > `Inline` > `Shared configuration package`.
+> The configuration file `.license-compliancerc.js` can also include other properties besides `extends`, allowing to override the settings from the installed shared package. The command line arguments override any configuration; priority `CLI` > `.license-compliancerc.js` > `shared configuration package`.
 
 # License
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { EOL } from "node:os";
 import { Format, Report } from "./enumerations.js";
 import { Configuration, ExtendableConfiguration } from "./interfaces.js";
+import { isLicenseValid } from "./license.js";
 import { processArgs } from "./program.js";
 import { isPathTraversalSafe } from "./util.js";
 
@@ -71,23 +72,22 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         query: mergedConfiguration.query || [],
         report: <Report>mergedConfiguration.report || Report.summary,
     };
-    console.log(configuration);
 
     // Validate configuration
     const result = joi
         .object({
-            allow: joi.array().items(joi.string()),
+            allow: joiLicense("allow"),
             development: joi.boolean().strict(),
             direct: joi.boolean().strict(),
             exclude: joi.array(),
             format: joi.string().valid(Format.csv, Format.json, Format.text, Format.xunit),
             production: joi.boolean().strict(),
-            query: joi.array().items(joi.string()),
+            query: joiLicense("query"),
             report: joi.string().valid(Report.detailed, Report.summary),
         })
         .messages({
-            "any.only": "extended option {{#label}} argument '{{#value}}' is invalid. Allowed choices are {{#valids}}.",
-            "boolean.base": "option {{#label}} argument '{{#value}}' is invalid. Expected boolean true or false.",
+            "any.only": "extended option {{#label}} value '{{#value}}' is invalid. Allowed choices are {{#valids}}.",
+            "boolean.base": "extended option {{#label}} value '{{#value}}' is invalid. Expected boolean true or false.",
         })
         .validate(configuration, {
             convert: false,
@@ -108,10 +108,25 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     configuration.direct = !!configuration.direct;
     configuration.production = !!configuration.production;
 
-    console.log(configuration);
     return configuration;
 }
 
 export function isComplianceModeEnabled(configuration: Pick<Configuration, "allow">): boolean {
     return Array.isArray(configuration.allow) && configuration.allow.length > 0;
+}
+
+function joiLicense(option: string): joi.ArraySchema<Array<string>> {
+    return joi
+        .array()
+        .items(joi.string())
+        .custom((licenses: Array<string>, helper): Array<string> | joi.ErrorReport => {
+            for (const license of licenses) {
+                if (!isLicenseValid(license)) {
+                    return helper.message({
+                        custom: `extended option ${option} value '${license}' is invalid.${EOL}Licenses must adhere to the SPDX specification.`,
+                    });
+                }
+            }
+            return licenses;
+        });
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,10 +4,10 @@ import joi from "joi";
 import path from "node:path";
 
 import { EOL } from "node:os";
-import { Formatter, Report } from "./enumerations.js";
+import { Format, Report } from "./enumerations.js";
 import { Configuration, ExtendableConfiguration } from "./interfaces.js";
 import { processArgs } from "./program.js";
-import { isPathTraversalSafe, toPascal } from "./util.js";
+import { isPathTraversalSafe } from "./util.js";
 
 const packageName = "license-compliance";
 
@@ -66,10 +66,10 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         development: !!mergedConfiguration.development || false,
         direct: mergedConfiguration.direct || false,
         exclude: mergedConfiguration.exclude || [],
-        format: <Formatter>toPascal(mergedConfiguration.format) || Formatter.text,
+        format: <Format>mergedConfiguration.format || Format.text,
         production: !!mergedConfiguration.production || false,
         query: mergedConfiguration.query || [],
-        report: <Report>toPascal(mergedConfiguration.report) || Report.summary,
+        report: <Report>mergedConfiguration.report || Report.summary,
     };
 
     // Validate configuration
@@ -79,7 +79,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             development: joi.boolean(),
             direct: joi.boolean(),
             exclude: joi.array(),
-            format: joi.string().valid(Formatter.csv, Formatter.json, Formatter.text, Formatter.xunit),
+            format: joi.string().valid(Format.csv, Format.json, Format.text, Format.xunit),
             production: joi.boolean(),
             query: joi.array().items(joi.string()),
             report: joi.string().valid(Report.detailed, Report.summary),

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -84,7 +84,17 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             query: joi.array().items(joi.string()),
             report: joi.string().valid(Report.detailed, Report.summary),
         })
-        .validate(configuration);
+        .messages({
+            "any.only": "extended option {{#label}} argument '{{#value}}' is invalid. Allowed choices are {{#valids}}.",
+        })
+        .validate(configuration, {
+            errors: {
+                wrap: {
+                    array: "",
+                    label: `'`,
+                },
+            },
+        });
     if (result.error) {
         console.error(chalk.red("Error:"), result.error.message);
         return null;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -63,31 +63,34 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     const mergedConfiguration = Object.assign(configExtended, <Partial<Configuration>>configInline, config);
     const configuration = {
         allow: mergedConfiguration.allow || [],
-        development: !!mergedConfiguration.development || false,
-        direct: mergedConfiguration.direct || false,
+        development: mergedConfiguration.development,
+        direct: mergedConfiguration.direct,
         exclude: mergedConfiguration.exclude || [],
         format: <Format>mergedConfiguration.format || Format.text,
-        production: !!mergedConfiguration.production || false,
+        production: mergedConfiguration.production,
         query: mergedConfiguration.query || [],
         report: <Report>mergedConfiguration.report || Report.summary,
     };
+    console.log(configuration);
 
     // Validate configuration
     const result = joi
         .object({
             allow: joi.array().items(joi.string()),
-            development: joi.boolean(),
-            direct: joi.boolean(),
+            development: joi.boolean().strict(),
+            direct: joi.boolean().strict(),
             exclude: joi.array(),
             format: joi.string().valid(Format.csv, Format.json, Format.text, Format.xunit),
-            production: joi.boolean(),
+            production: joi.boolean().strict(),
             query: joi.array().items(joi.string()),
             report: joi.string().valid(Report.detailed, Report.summary),
         })
         .messages({
             "any.only": "extended option {{#label}} argument '{{#value}}' is invalid. Allowed choices are {{#valids}}.",
+            "boolean.base": "option {{#label}} argument '{{#value}}' is invalid. Expected boolean true or false.",
         })
         .validate(configuration, {
+            convert: false,
             errors: {
                 wrap: {
                     array: "",
@@ -100,6 +103,12 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         return null;
     }
 
+    // Default booleans
+    configuration.development = !!configuration.development;
+    configuration.direct = !!configuration.direct;
+    configuration.production = !!configuration.production;
+
+    console.log(configuration);
     return configuration;
 }
 

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -1,8 +1,8 @@
-export enum Formatter {
-    csv = "Csv",
-    json = "Json",
-    text = "Text",
-    xunit = "Xunit",
+export enum Format {
+    csv = "csv",
+    json = "json",
+    text = "text",
+    xunit = "xunit",
 }
 
 export enum LicenseStatus {
@@ -17,6 +17,6 @@ export enum Literals {
 }
 
 export enum Report {
-    detailed = "Detailed",
-    summary = "Summary",
+    detailed = "detailed",
+    summary = "summary",
 }

--- a/src/formatters/factory.ts
+++ b/src/formatters/factory.ts
@@ -1,4 +1,5 @@
-import { Formatter as FormatterName } from "../enumerations.js";
+import { Format } from "../enumerations.js";
+import { toPascal } from "../util.js";
 import { Csv } from "./csv.js";
 import { Formatter } from "./formatter.js";
 import { Json } from "./json.js";
@@ -6,8 +7,12 @@ import { Text } from "./text.js";
 import { Xunit } from "./xunit.js";
 
 export class Factory {
-    static getInstance(format: FormatterName): Formatter {
-        const classes = { Csv, Json, Text, Xunit };
-        return new classes[format]();
+    static getInstance(className: string): Formatter {
+        if (className in Format) {
+            const classes = { Csv, Json, Text, Xunit };
+            type type = keyof typeof classes;
+            return new classes[<type>toPascal(className)]();
+        }
+        throw new Error(`Invalid format type: '${className}'`);
     }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,11 @@
-import { Formatter, LicenseStatus, Report } from "./enumerations.js";
+import { Format, LicenseStatus, Report } from "./enumerations.js";
 
 export interface Configuration {
     allow: Array<string>;
     development: boolean;
     direct: boolean;
     exclude: Array<string | RegExp>;
-    format: Formatter;
+    format: Format;
     production: boolean;
     query: Array<string>;
     report: Report;

--- a/src/program.ts
+++ b/src/program.ts
@@ -3,7 +3,7 @@ import { Command, CommanderError, InvalidArgumentError, Option } from "commander
 import { EOL } from "node:os";
 
 import packInfo from "../package.json" with { type: "json" };
-import { Formatter, Literals, Report } from "./enumerations.js";
+import { Format, Literals, Report } from "./enumerations.js";
 import { Configuration } from "./interfaces.js";
 import { isLicenseValid } from "./license.js";
 
@@ -27,7 +27,7 @@ export function processArgs(): Configuration {
         .option("-t, --direct", "Analyzes only direct dependencies (depth = 1).")
         .addOption(
             new Option("-f, --format <format>", "Report format, csv, text, or json (default = text).").choices(
-                Object.keys(Formatter),
+                Object.keys(Format),
             ),
         )
         .addOption(

--- a/src/reports/factory.ts
+++ b/src/reports/factory.ts
@@ -1,12 +1,17 @@
-import { Formatter as FormatterName, Report } from "../enumerations.js";
+import { Format, Report } from "../enumerations.js";
 import { Factory as FormatFactory } from "../formatters/index.js";
+import { toPascal } from "../util.js";
 import { Detailed } from "./detailed.js";
 import { Reporter } from "./reporter.js";
 import { Summary } from "./summary.js";
 
 export class Factory {
-    static getInstance(type: Report, format: FormatterName): Reporter {
-        const classes = { Detailed, Summary };
-        return new classes[type](FormatFactory.getInstance(format));
+    static getInstance(className: string, format: Format): Reporter {
+        if (className in Report) {
+            const classes = { Detailed, Summary };
+            type type = keyof typeof classes;
+            return new classes[<type>toPascal(className)](FormatFactory.getInstance(format));
+        }
+        throw new Error(`Invalid report type: '${className}'`);
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,9 +37,9 @@ export async function readPackageJson(packagePath: string): Promise<NpmPackage |
     return null;
 }
 
-export function toPascal(value: string | undefined): string | undefined {
+export function toPascal(value: string): string {
     if (!value || value.length < 2) {
-        return value;
+        return value || "";
     }
     return value[0].toUpperCase() + value.substring(1);
 }

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -169,6 +169,36 @@ test.serial("Inline configuration, invalid extended file", async (t): Promise<vo
     t.is(config, null);
 });
 
+test.serial("Inline configuration, invalid license", async (t): Promise<void> => {
+    // Inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["invalid-license"],
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+    sinon.stub(explorer, "load").returns(Promise.resolve(null));
+
+    // No command line args
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => <Configuration>{},
+        },
+    });
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(stubStderr.calledWithMatch("extended option allow value 'invalid-license' is invalid."));
+});
+
 test.serial("Inline configuration, extended null", async (t): Promise<void> => {
     // Inline configuration
     const explorer: Explorer = createExplorer();

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -3,7 +3,7 @@ import cosmiconfig from "cosmiconfig";
 import esmock from "esmock";
 import sinon from "sinon";
 
-import { Formatter, Report } from "../../src/enumerations.js";
+import { Format, Report } from "../../src/enumerations.js";
 import { Configuration } from "../../src/interfaces.js";
 
 const NODE_MODULES = "node_modules";
@@ -75,7 +75,7 @@ test.serial("Default configuration", async (t): Promise<void> => {
     t.false(config?.direct);
     t.is(config?.exclude.length, 0);
     t.false(config?.production);
-    t.is(config?.format, Formatter.text);
+    t.is(config?.format, Format.text);
     t.is(config?.report, Report.summary);
 });
 
@@ -115,7 +115,7 @@ test.serial("Inline configuration, not extended", async (t): Promise<void> => {
             config: {
                 production: true,
                 allow: ["MIT", "ISC"],
-                format: Formatter.json.toLowerCase(),
+                format: Format.json.toLowerCase(),
             },
             filepath: "some-path",
             isEmpty: false,
@@ -140,7 +140,7 @@ test.serial("Inline configuration, not extended", async (t): Promise<void> => {
     t.false(config?.direct);
     t.is(config?.exclude.length, 0);
     t.true(config?.production);
-    t.is(config?.format, Formatter.json);
+    t.is(config?.format, Format.json);
     t.is(config?.report, Report.summary);
 });
 
@@ -203,7 +203,7 @@ test.serial("Inline configuration, extended null", async (t): Promise<void> => {
     t.false(config?.direct);
     t.is(config?.exclude.length, 0);
     t.false(config?.production);
-    t.is(config?.format, Formatter.text);
+    t.is(config?.format, Format.text);
     t.is(config?.report, Report.detailed);
 });
 
@@ -286,7 +286,7 @@ test.serial("Inline configuration, extended", async (t): Promise<void> => {
         Promise.resolve({
             config: {
                 allow: ["MIT", "ISC"],
-                format: Formatter.json.toLowerCase(),
+                format: Format.json.toLowerCase(),
                 production: true,
             },
             filepath: "some-path",
@@ -311,7 +311,7 @@ test.serial("Inline configuration, extended", async (t): Promise<void> => {
     t.true(config?.direct);
     t.is(config?.exclude.length, 0);
     t.true(config?.production);
-    t.is(config?.format, Formatter.json);
+    t.is(config?.format, Format.json);
     t.is(config?.report, Report.detailed);
 });
 

--- a/tests/formatters/factory.spec.ts
+++ b/tests/formatters/factory.spec.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import { Formatter } from "../../src/enumerations.js";
+import { Format } from "../../src/enumerations.js";
 import { Csv } from "../../src/formatters/csv.js";
 import { Factory } from "../../src/formatters/factory.js";
 import { Json } from "../../src/formatters/json.js";
@@ -8,25 +8,33 @@ import { Text } from "../../src/formatters/text.js";
 import { Xunit } from "../../src/formatters/xunit.js";
 
 test("Csv", (t): void => {
-    const formatter = Factory.getInstance(Formatter.csv);
+    const formatter = Factory.getInstance(Format.csv);
 
     t.true(formatter instanceof Csv);
 });
 
 test("Json", (t): void => {
-    const formatter = Factory.getInstance(Formatter.json);
+    const formatter = Factory.getInstance(Format.json);
 
     t.true(formatter instanceof Json);
 });
 
 test("Text", (t): void => {
-    const formatter = Factory.getInstance(Formatter.text);
+    const formatter = Factory.getInstance(Format.text);
 
     t.true(formatter instanceof Text);
 });
 
 test("Xunit", (t): void => {
-    const formatter = Factory.getInstance(Formatter.xunit);
+    const formatter = Factory.getInstance(Format.xunit);
 
     t.true(formatter instanceof Xunit);
+});
+
+test("Invalid", (t): void => {
+    const error = t.throws((): void => {
+        Factory.getInstance("Invalid");
+    });
+
+    t.is(error.message, "Invalid format type: 'Invalid'");
 });

--- a/tests/main/main.spec.ts
+++ b/tests/main/main.spec.ts
@@ -2,11 +2,11 @@ import test from "ava";
 import esmock from "esmock";
 import sinon from "sinon";
 
-import { Formatter, Report } from "../src/enumerations.js";
-import { Text } from "../src/formatters/text.js";
-import { Configuration, Package } from "../src/interfaces.js";
-import * as reports from "../src/reports/index.js";
-import { Summary } from "../src/reports/summary.js";
+import { Format, Report } from "../../src/enumerations.js";
+import { Text } from "../../src/formatters/text.js";
+import { Configuration, Package } from "../../src/interfaces.js";
+import * as reports from "../../src/reports/index.js";
+import { Summary } from "../../src/reports/summary.js";
 
 test.beforeEach((): void => {
     sinon.stub(process.stdout, "write");
@@ -18,8 +18,8 @@ test.afterEach((): void => {
 });
 
 test.serial("node_modules not found", async (t): Promise<void> => {
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve(null),
         },
     });
@@ -29,11 +29,11 @@ test.serial("node_modules not found", async (t): Promise<void> => {
 });
 
 test.serial("Invalid arguments", async (t): Promise<void> => {
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> => Promise.resolve(null),
         },
     });
@@ -45,14 +45,14 @@ test.serial("Invalid arguments", async (t): Promise<void> => {
 
 test.serial("No packages installed", async (t): Promise<void> => {
     const packages = new Array<Package>();
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> => Promise.resolve(getMockConfiguration()),
         },
-        "../src/npm.js": {
+        "../../src/npm.js": {
             getInstalledPackages: (): Promise<Array<Package>> => Promise.resolve(packages),
         },
     });
@@ -73,27 +73,27 @@ test.serial("Get licenses summary", async (t): Promise<void> => {
     });
 
     const stubReport = sinon.stub(reports.Factory, "getInstance").returns(new Summary(new Text()));
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> => Promise.resolve(getMockConfiguration()),
         },
-        "../src/npm.js": {
+        "../../src/npm.js": {
             getInstalledPackages: (): Promise<Array<Package>> => Promise.resolve(packages),
         },
-        "../src/filters.js": {
+        "../../src/filters.js": {
             excludePackages: (): Array<Package> => packages,
         },
-        "../src/license.js": {
+        "../../src/license.js": {
             onlyAllow: (): Array<Package> => packages,
         },
     });
 
     const r = await main();
 
-    t.true(stubReport.calledOnceWith(Report.summary, Formatter.text));
+    t.true(stubReport.calledOnceWith(Report.summary, Format.text));
     t.true(r);
 });
 
@@ -108,11 +108,11 @@ test.serial("Not allowed licenses", async (t): Promise<void> => {
     });
 
     const stubReport = sinon.stub(reports.Factory, "getInstance").returns(new Summary(new Text()));
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> =>
                 Promise.resolve(
                     getMockConfiguration({
@@ -120,20 +120,20 @@ test.serial("Not allowed licenses", async (t): Promise<void> => {
                     }),
                 ),
         },
-        "../src/npm.js": {
+        "../../src/npm.js": {
             getInstalledPackages: (): Promise<Array<Package>> => Promise.resolve(packages),
         },
-        "../src/filters.js": {
+        "../../src/filters.js": {
             excludePackages: (): Array<Package> => packages,
         },
-        "../src/license.js": {
+        "../../src/license.js": {
             onlyAllow: (): Array<Package> => packages,
         },
     });
 
     const r = await main();
 
-    t.true(stubReport.calledOnceWith(Report.summary, Formatter.text));
+    t.true(stubReport.calledOnceWith(Report.summary, Format.text));
     t.false(r);
 });
 
@@ -147,11 +147,11 @@ test.serial("Success", async (t): Promise<void> => {
         repository: "company/project",
     });
 
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> =>
                 Promise.resolve(
                     getMockConfiguration({
@@ -159,13 +159,13 @@ test.serial("Success", async (t): Promise<void> => {
                     }),
                 ),
         },
-        "../src/npm.js": {
+        "../../src/npm.js": {
             getInstalledPackages: (): Promise<Array<Package>> => Promise.resolve(packages),
         },
-        "../src/filters.js": {
+        "../../src/filters.js": {
             excludePackages: (): Array<Package> => packages,
         },
-        "../src/license.js": {
+        "../../src/license.js": {
             onlyAllow: (): Array<Package> => new Array<Package>(),
         },
     });
@@ -185,11 +185,11 @@ test.serial("Success query", async (t): Promise<void> => {
         repository: "company/project",
     });
 
-    const { main } = await esmock("../src/main.js", {
-        "../src/node-modules.js": {
+    const { main } = await esmock("../../src/main.js", {
+        "../../src/node-modules.js": {
             getNodeModulesPath: (): Promise<string | null> => Promise.resolve("/"),
         },
-        "../src/configuration.js": {
+        "../../src/configuration.js": {
             getConfiguration: (): Promise<Configuration | null> =>
                 Promise.resolve(
                     getMockConfiguration({
@@ -197,14 +197,14 @@ test.serial("Success query", async (t): Promise<void> => {
                     }),
                 ),
         },
-        "../src/npm.js": {
+        "../../src/npm.js": {
             getInstalledPackages: (): Promise<Array<Package>> => Promise.resolve(packages),
         },
-        "../src/filters.js": {
+        "../../src/filters.js": {
             excludePackages: (): Array<Package> => packages,
             queryPackages: (): Array<Package> => new Array<Package>(),
         },
-        "../src/license.js": {
+        "../../src/license.js": {
             onlyAllow: (): Array<Package> => new Array<Package>(),
         },
     });
@@ -221,7 +221,7 @@ function getMockConfiguration(overrideConfiguration?: Partial<Configuration>): C
             development: false,
             direct: false,
             exclude: [],
-            format: Formatter.text,
+            format: Format.text,
             production: false,
             query: [],
             report: Report.summary,

--- a/tests/program/processArgs.spec.ts
+++ b/tests/program/processArgs.spec.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import sinon from "sinon";
 
 import packInfo from "../../package.json" with { type: "json" };
-import { Formatter, Report } from "../../src/enumerations.js";
+import { Format, Report } from "../../src/enumerations.js";
 import { processArgs } from "../../src/program.js";
 
 test.before((): void => {
@@ -97,7 +97,7 @@ test("Format", (t): void => {
     t.true(configuration.development === undefined);
     t.true(configuration.direct === undefined);
     t.true(configuration.exclude === undefined);
-    t.true(configuration.format === Formatter.json.toLowerCase());
+    t.true(configuration.format === Format.json);
     t.true(configuration.production === undefined);
     t.true(configuration.report === undefined);
 });

--- a/tests/reports/factory.spec.ts
+++ b/tests/reports/factory.spec.ts
@@ -1,18 +1,26 @@
 import test from "ava";
 
-import { Formatter, Report } from "../../src/enumerations.js";
+import { Format, Report } from "../../src/enumerations.js";
 import { Detailed } from "../../src/reports/detailed.js";
 import { Factory } from "../../src/reports/factory.js";
 import { Summary } from "../../src/reports/summary.js";
 
 test("Detail", (t): void => {
-    const report = Factory.getInstance(Report.detailed, Formatter.text);
+    const report = Factory.getInstance(Report.detailed, Format.text);
 
     t.true(report instanceof Detailed);
 });
 
 test("Summary", (t): void => {
-    const report = Factory.getInstance(Report.summary, Formatter.text);
+    const report = Factory.getInstance(Report.summary, Format.text);
 
     t.true(report instanceof Summary);
+});
+
+test("Invalid", (t): void => {
+    const error = t.throws((): void => {
+        Factory.getInstance("Invalid", Format.text);
+    });
+
+    t.is(error.message, "Invalid report type: 'Invalid'");
 });

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-import { Formatter, Report } from "../src/enumerations.js";
+import { Format, Report } from "../src/enumerations.js";
 import { Configuration } from "../src/interfaces.js";
 
 export function readJson(path: string): unknown {
@@ -14,7 +14,7 @@ export function getDefaultConfiguration(): Configuration {
         direct: false,
         exclude: [],
         production: false,
-        format: Formatter.text,
+        format: Format.text,
         query: [],
         report: Report.summary,
     };


### PR DESCRIPTION
# Summary

Extended configuration using `.license-compliancerc.js` or `extends: module`:

* Does not validate `allow` and `query` for proper SPDX licenses.  Originally reported by @mvayngrib , proposed solution in PR #219 .
* Does not force strict boolean (true or false) for `development`, `direct`, and `production`.
