### PR TITLE
fix: allow and query arg override

### DIFF
--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -3,7 +3,7 @@ export default {
     development: true,
     direct: true,
     exclude: [/^spdx/, "yaml"],
-    // extends: "@tmorell/license-policy",
+    extends: "@tmorell/license-policy",
     format: "text",
     production: true,
     report: "summary",

--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -3,7 +3,7 @@ export default {
     development: true,
     direct: true,
     exclude: [/^spdx/, "yaml"],
-    extends: "@tmorell/license-policy",
+    // extends: "@tmorell/license-policy",
     format: "text",
     production: true,
     report: "summary",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,7 +34,6 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             }
 
             const c = await explorer.load(confPath);
-            console.log("c", c);
             configExtended = <Partial<Configuration>>c?.config || {};
             delete configInline.extends;
         } catch (error: unknown) {
@@ -61,7 +60,25 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         return null;
     }
 
-    // Merge configurations: CLI > inline > extended
+    // Allow and query mutual overrides
+    if (configArgs.allow) {
+        if (configExtended) {
+            configExtended.query = [];
+        }
+        if (configInline) {
+            configInline.query = [];
+        }
+    }
+    if (configArgs.query) {
+        if (configExtended) {
+            configExtended.allow = [];
+        }
+        if (configInline) {
+            configInline.allow = [];
+        }
+    }
+
+    // Merge configurations: args > inline > extended
     const mergedConfiguration = { ...configExtended, ...(<Partial<Configuration>>configInline), ...configArgs };
     const configuration = {
         allow: mergedConfiguration.allow || [],
@@ -73,16 +90,6 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         query: mergedConfiguration.query || [],
         report: <Report>mergedConfiguration.report || Report.summary,
     };
-
-    // Allow and query overrides
-    console.log("allow", configArgs?.allow, configInline?.allow, configExtended?.allow);
-    console.log("query", configArgs?.query, configInline?.query, configExtended?.query);
-    if (configArgs.allow && (configInline.query || configExtended.query)) {
-        configuration.query = [];
-    }
-    if (configArgs.query && (configInline.allow || configExtended.allow)) {
-        configuration.allow = [];
-    }
 
     // Validate configuration
     const result = joi
@@ -118,8 +125,6 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     configuration.development = !!configuration.development;
     configuration.direct = !!configuration.direct;
     configuration.production = !!configuration.production;
-
-    console.log(configuration);
 
     return configuration;
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,6 +34,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             }
 
             const c = await explorer.load(confPath);
+            console.log("c", c);
             configExtended = <Partial<Configuration>>c?.config || {};
             delete configInline.extends;
         } catch (error: unknown) {
@@ -53,15 +54,15 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     }
 
     // Get args configuration
-    let config: Configuration;
+    let configArgs: Configuration;
     try {
-        config = processArgs();
+        configArgs = processArgs();
     } catch {
         return null;
     }
 
     // Merge configurations: CLI > inline > extended
-    const mergedConfiguration = Object.assign(configExtended, <Partial<Configuration>>configInline, config);
+    const mergedConfiguration = { ...configExtended, ...(<Partial<Configuration>>configInline), ...configArgs };
     const configuration = {
         allow: mergedConfiguration.allow || [],
         development: mergedConfiguration.development,
@@ -72,6 +73,16 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         query: mergedConfiguration.query || [],
         report: <Report>mergedConfiguration.report || Report.summary,
     };
+
+    // Allow and query overrides
+    console.log("allow", configArgs?.allow, configInline?.allow, configExtended?.allow);
+    console.log("query", configArgs?.query, configInline?.query, configExtended?.query);
+    if (configArgs.allow && (configInline.query || configExtended.query)) {
+        configuration.query = [];
+    }
+    if (configArgs.query && (configInline.allow || configExtended.allow)) {
+        configuration.allow = [];
+    }
 
     // Validate configuration
     const result = joi
@@ -107,6 +118,8 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     configuration.development = !!configuration.development;
     configuration.direct = !!configuration.direct;
     configuration.production = !!configuration.production;
+
+    console.log(configuration);
 
     return configuration;
 }

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -1,8 +1,9 @@
-import test from "ava";
+import test, { ExecutionContext } from "ava";
 import cosmiconfig from "cosmiconfig";
 import esmock from "esmock";
 import sinon from "sinon";
 
+import { getConfiguration as getConfigurationFunc } from "../../src/configuration.js";
 import { Format, Report } from "../../src/enumerations.js";
 import { Configuration } from "../../src/interfaces.js";
 
@@ -30,16 +31,25 @@ test.beforeEach((): void => {
     stubStderr = sinon.stub(process.stderr, "write");
 });
 
-test.afterEach((): void => {
+test.afterEach.always((): void => {
     sinon.restore();
 });
 
-test.serial("Command lined args failed", async (t): Promise<void> => {
-    // No inline configuration
+// Default config, no args, no inline, no extended
+
+test.serial("Default configuration", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(Promise.resolve(null));
 
-    // Command line args
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    assertDefaultConfig(t, config);
+});
+
+// Command line args
+
+test.serial("Command args invalid input", async (t): Promise<void> => {
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => {
@@ -48,66 +58,107 @@ test.serial("Command lined args failed", async (t): Promise<void> => {
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.is(config, null);
 });
 
-test.serial("Default configuration", async (t): Promise<void> => {
-    // No inline configuration
-    const explorer: Explorer = createExplorer();
-    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
-
-    // No command line args
+test.serial("Command args success", async (t): Promise<void> => {
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
+            processArgs: (): Configuration => {
+                return {
+                    allow: ["MIT"],
+                    development: false,
+                    direct: true,
+                    exclude: [/@acme/],
+                    format: Format.json,
+                    production: true,
+                    query: [],
+                    report: Report.detailed,
+                };
+            },
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.not(config, null);
-    t.is(config?.allow.length, 0);
-    t.false(config?.development);
-    t.false(config?.direct);
-    t.is(config?.exclude.length, 0);
-    t.false(config?.production);
-    t.is(config?.format, Format.text);
-    t.is(config?.report, Report.summary);
+    t.is(config.allow.length, 1);
+    t.is(config.allow[0], "MIT");
+    t.false(config.development);
+    t.true(config.direct);
+    t.is(config.exclude.length, 1);
+    t.is(config.format, Format.json);
+    t.true(config.production);
+    t.is(config.query.length, 0);
+    t.is(config.report, Report.detailed);
 });
 
-test.serial("Invalid inline configuration", async (t): Promise<void> => {
-    // No inline configuration
+// Inline only
+
+test.serial("Inline invalid enumeration value", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
         Promise.resolve({
             config: {
-                format: "some-format",
+                format: "invalid-format",
             },
-            filepath: "some-path",
-            isEmpty: false,
+            filepath: "path",
         }),
     );
 
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
+    const config = await getConfigurationFunc(NODE_MODULES);
 
     t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(
+        stubStderr.calledWithMatch(
+            "extended option 'format' value 'invalid-format' is invalid. Allowed choices are csv, json, text, xunit.",
+        ),
+    );
 });
 
-test.serial("Inline configuration, not extended", async (t): Promise<void> => {
-    // No inline configuration
+test.serial("Inline invalid allow license", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["invalid-license"],
+            },
+            filepath: "path",
+        }),
+    );
+
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(stubStderr.calledWithMatch("extended option allow value 'invalid-license' is invalid."));
+});
+
+test.serial("Inline invalid query license", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                query: ["invalid-license"],
+            },
+            filepath: "path",
+        }),
+    );
+
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(stubStderr.calledWithMatch("extended option query value 'invalid-license' is invalid."));
+});
+
+test.serial("Inline success", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
@@ -115,22 +166,14 @@ test.serial("Inline configuration, not extended", async (t): Promise<void> => {
             config: {
                 production: true,
                 allow: ["MIT", "ISC"],
-                format: Format.json.toLowerCase(),
+                format: Format.json,
+                report: Report.detailed,
             },
-            filepath: "some-path",
-            isEmpty: false,
+            filepath: "path",
         }),
     );
 
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
+    const config = await getConfigurationFunc(NODE_MODULES);
 
     t.not(config, null);
     t.is(config?.allow.length, 2);
@@ -141,212 +184,131 @@ test.serial("Inline configuration, not extended", async (t): Promise<void> => {
     t.is(config?.exclude.length, 0);
     t.true(config?.production);
     t.is(config?.format, Format.json);
-    t.is(config?.report, Report.summary);
-});
-
-test.serial("Inline configuration, invalid extended file", async (t): Promise<void> => {
-    // Inline configuration
-    const explorer: Explorer = createExplorer();
-    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
-    sinon.stub(explorer, "search").returns(
-        Promise.resolve({
-            config: {
-                allow: ["Apache-2.0"],
-                report: Report.detailed.toLowerCase(),
-                extends: "@acme/some-invalid-file",
-            },
-            filepath: "some-path",
-            isEmpty: false,
-        }),
-    );
-    sinon.stub(explorer, "load").throws("ENOENT: no such file or directory");
-
-    const { getConfiguration } = await esmock("../../src/configuration.js");
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
-
-    t.is(config, null);
-});
-
-test.serial("Inline configuration, invalid license", async (t): Promise<void> => {
-    // Inline configuration
-    const explorer: Explorer = createExplorer();
-    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
-    sinon.stub(explorer, "search").returns(
-        Promise.resolve({
-            config: {
-                allow: ["invalid-license"],
-            },
-            filepath: "some-path",
-            isEmpty: false,
-        }),
-    );
-    sinon.stub(explorer, "load").returns(Promise.resolve(null));
-
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
-
-    t.is(config, null);
-    t.true(stubStderr.calledOnce);
-    t.true(stubStderr.calledWithMatch("extended option allow value 'invalid-license' is invalid."));
-});
-
-test.serial("Inline configuration, extended null", async (t): Promise<void> => {
-    // Inline configuration
-    const explorer: Explorer = createExplorer();
-    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
-    sinon.stub(explorer, "search").returns(
-        Promise.resolve({
-            config: {
-                allow: ["Apache-2.0"],
-                report: Report.detailed.toLowerCase(),
-                extends: "@acme/license-policy",
-            },
-            filepath: "some-path",
-            isEmpty: false,
-        }),
-    );
-    sinon.stub(explorer, "load").returns(Promise.resolve(null));
-
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
-
-    t.not(config, null);
-    t.is(config?.allow.length, 1);
-    t.is(config?.allow[0], "Apache-2.0");
-    t.false(config?.development);
-    t.false(config?.direct);
-    t.is(config?.exclude.length, 0);
-    t.false(config?.production);
-    t.is(config?.format, Format.text);
     t.is(config?.report, Report.detailed);
 });
 
-test.serial("Transversal execution", async (t): Promise<void> => {
-    // Inline configuration
+// Extended
+
+test.serial("Extended unknown loading error", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
         Promise.resolve({
             config: {
-                allow: ["Apache-2.0"],
-                report: Report.detailed.toLowerCase(),
-                extends: "../@acme/license-policy",
+                extends: "@acme/non-existent-file",
             },
-            filepath: "some-path",
-            isEmpty: false,
+            filepath: "path",
         }),
     );
+    sinon.stub(explorer, "load").throws(Object.assign(new Error("Unknown error"), { code: "a-code" }));
 
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
+    const config = await getConfigurationFunc(NODE_MODULES);
 
     t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(stubStderr.calledWithMatch("Could not load the extended configuration module"));
 });
 
-test.serial("Non-existing extend package", async (t): Promise<void> => {
-    // Inline configuration
+test.serial("Extended non-existent file", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
-    sinon.stub(explorer, "load").throws(Object.assign(new Error("File not found"), { code: "ENOENT" }));
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
         Promise.resolve({
             config: {
-                allow: ["Apache-2.0"],
-                report: Report.detailed.toLowerCase(),
-                extends: "@acme/license-policy",
+                extends: "@acme/non-existent-file",
             },
-            filepath: "some-path",
-            isEmpty: false,
+            filepath: "path",
         }),
     );
+    sinon
+        .stub(explorer, "load")
+        .throws(Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }));
 
-    // No command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{},
-        },
-    });
+    const config = await getConfigurationFunc(NODE_MODULES);
 
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
     t.is(config, null);
     t.true(stubStderr.calledOnce);
     t.true(stubStderr.calledWithMatch("was not found"));
 });
 
-test.serial("Inline configuration, extended", async (t): Promise<void> => {
-    // Inline configuration
+test.serial("Extended transversal execution", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
         Promise.resolve({
             config: {
-                allow: ["Apache-2.0"],
-                report: Report.detailed.toLowerCase(),
+                extends: "../@acme/license-policy",
+            },
+            filepath: "path",
+        }),
+    );
+
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    t.is(config, null);
+    t.true(stubStderr.calledOnce);
+    t.true(stubStderr.calledWithMatch("resolves outside of node_modules"));
+});
+
+test.serial("Extended null package", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
                 extends: "@acme/license-policy",
             },
-            filepath: "some-path",
-            isEmpty: false,
+            filepath: "path",
+        }),
+    );
+    sinon.stub(explorer, "load").returns(Promise.resolve(null));
+
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    assertDefaultConfig(t, config);
+});
+
+test.serial("Extended success", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                extends: "@acme/license-policy",
+            },
+            filepath: "path",
         }),
     );
     sinon.stub(explorer, "load").returns(
         Promise.resolve({
             config: {
                 allow: ["MIT", "ISC"],
-                format: Format.json.toLowerCase(),
+                format: Format.json,
                 production: true,
             },
-            filepath: "some-path",
+            filepath: "path",
             isEmpty: false,
         }),
     );
 
-    // Command line args
-    const { getConfiguration } = await esmock("../../src/configuration.js", {
-        "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{ direct: true },
-        },
-    });
-
-    // Get configuration
-    const config = await getConfiguration(NODE_MODULES);
+    const config = await getConfigurationFunc(NODE_MODULES);
 
     t.not(config, null);
-    t.is(config?.allow.length, 1);
-    t.is(config?.allow[0], "Apache-2.0");
+    t.is(config?.allow.length, 2);
+    t.is(config?.allow[0], "MIT");
+    t.is(config?.allow[1], "ISC");
     t.false(config?.development);
-    t.true(config?.direct);
+    t.false(config?.direct);
     t.is(config?.exclude.length, 0);
-    t.true(config?.production);
     t.is(config?.format, Format.json);
-    t.is(config?.report, Report.detailed);
+    t.true(config?.production);
+    t.is(config?.query.length, 0);
+    t.is(config?.report, Report.summary);
 });
 
-test.serial("args allow override query (.license-compliancerc.js)", async (t): Promise<void> => {
-    // No inline configuration
+// Overwrite allow / query
+
+test.serial("Overwrite allow -> query (inline)", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
@@ -354,29 +316,26 @@ test.serial("args allow override query (.license-compliancerc.js)", async (t): P
             config: {
                 query: ["MIT", "ISC"],
             },
-            filepath: "some-path",
+            filepath: "path",
             isEmpty: false,
         }),
     );
-
-    // Command line args
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{ allow: ["0BSD"] },
+            processArgs: (): Configuration => <Configuration>{ allow: ["Apache-2.0", "0BSD"] },
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.not(config, null);
     t.is(config?.query.length, 0);
-    t.is(config?.allow.length, 1);
-    t.is(config?.allow[0], "0BSD");
+    t.is(config?.allow.length, 2);
+    t.is(config?.allow[0], "Apache-2.0");
+    t.is(config?.allow[1], "0BSD");
 });
 
-test.serial("args query override allow (.license-compliancerc.js)", async (t): Promise<void> => {
-    // No inline configuration
+test.serial("Overwrite query -> allow (inline)", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
@@ -384,29 +343,26 @@ test.serial("args query override allow (.license-compliancerc.js)", async (t): P
             config: {
                 allow: ["MIT", "ISC"],
             },
-            filepath: "some-path",
+            filepath: "path",
             isEmpty: false,
         }),
     );
-
-    // Command line args
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
-            processArgs: (): Configuration => <Configuration>{ query: ["0BSD"] },
+            processArgs: (): Configuration => <Configuration>{ query: ["Apache-2.0", "0BSD"] },
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.not(config, null);
     t.is(config?.allow.length, 0);
-    t.is(config?.query.length, 1);
-    t.is(config?.query[0], "0BSD");
+    t.is(config?.query.length, 2);
+    t.is(config?.query[0], "Apache-2.0");
+    t.is(config?.query[1], "0BSD");
 });
 
-test.serial("args allow override query (extended)", async (t): Promise<void> => {
-    // No inline configuration
+test.serial("Overwrite allow -> query (extended)", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
@@ -414,7 +370,7 @@ test.serial("args allow override query (extended)", async (t): Promise<void> => 
             config: {
                 extends: "@acme/license-policy",
             },
-            filepath: "some-path",
+            filepath: "path",
             isEmpty: false,
         }),
     );
@@ -424,15 +380,12 @@ test.serial("args allow override query (extended)", async (t): Promise<void> => 
             filepath: "node_modules/@acme/license-policy/index.js",
         }),
     );
-
-    // Command line args
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => <Configuration>{ allow: ["0BSD"] },
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.not(config, null);
@@ -441,8 +394,7 @@ test.serial("args allow override query (extended)", async (t): Promise<void> => 
     t.is(config?.allow[0], "0BSD");
 });
 
-test.serial("args query override allow (extended)", async (t): Promise<void> => {
-    // No inline configuration
+test.serial("Overwrite query -> allow (extended)", async (t): Promise<void> => {
     const explorer: Explorer = createExplorer();
     sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
     sinon.stub(explorer, "search").returns(
@@ -450,7 +402,7 @@ test.serial("args query override allow (extended)", async (t): Promise<void> => 
             config: {
                 extends: "@acme/license-policy",
             },
-            filepath: "some-path",
+            filepath: "path",
             isEmpty: false,
         }),
     );
@@ -460,15 +412,12 @@ test.serial("args query override allow (extended)", async (t): Promise<void> => 
             filepath: "node_modules/@acme/license-policy/index.js",
         }),
     );
-
-    // Command line args
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => <Configuration>{ query: ["0BSD"] },
         },
     });
 
-    // Get configuration
     const config = await getConfiguration(NODE_MODULES);
 
     t.not(config, null);
@@ -476,6 +425,136 @@ test.serial("args query override allow (extended)", async (t): Promise<void> => 
     t.is(config?.query.length, 1);
     t.is(config?.query[0], "0BSD");
 });
+
+// Hierarchy overwrite
+
+test.serial("Hierarchy overwrite extended <- inline", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["MIT"],
+                extends: "@acme/license-policy",
+            },
+            filepath: "path",
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: {
+                allow: ["ISC"],
+            },
+            filepath: "path",
+            isEmpty: false,
+        }),
+    );
+
+    const config = await getConfigurationFunc(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "MIT");
+});
+
+test.serial("Hierarchy overwrite extended <- args", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                extends: "@acme/license-policy",
+            },
+            filepath: "path",
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: {
+                allow: ["ISC"],
+            },
+            filepath: "path",
+            isEmpty: false,
+        }),
+    );
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => {
+                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+            },
+        },
+    });
+
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "MIT");
+});
+
+test.serial("Hierarchy overwrite inline <- args", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["0BSD", "ISC"],
+            },
+            filepath: "path",
+        }),
+    );
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => {
+                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+            },
+        },
+    });
+
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "MIT");
+});
+
+test.serial("Hierarchy overwrite extended <- inline <- args", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["Apache-2.0"],
+                extends: "@acme/license-policy",
+            },
+            filepath: "path",
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: {
+                allow: ["ISC"],
+            },
+            filepath: "path",
+            isEmpty: false,
+        }),
+    );
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => {
+                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+            },
+        },
+    });
+
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "MIT");
+});
+
+// Utils
 
 function createExplorer(): Explorer {
     return {
@@ -490,5 +569,30 @@ function createExplorer(): Explorer {
         clearCaches: (): void => {
             return;
         },
+    };
+}
+
+function assertDefaultConfig(t: ExecutionContext<unknown>, config: Configuration | null): void {
+    t.not(config, null);
+    t.is(config?.allow.length, 0);
+    t.false(config?.development);
+    t.false(config?.direct);
+    t.is(config?.exclude.length, 0);
+    t.is(config?.format, Format.text);
+    t.false(config?.production);
+    t.is(config?.query.length, 0);
+    t.is(config?.report, Report.summary);
+}
+
+function getDefaultConfig(): Configuration {
+    return {
+        allow: [],
+        development: false,
+        direct: false,
+        exclude: [],
+        format: Format.text,
+        production: false,
+        query: [],
+        report: Report.summary,
     };
 }

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -345,6 +345,138 @@ test.serial("Inline configuration, extended", async (t): Promise<void> => {
     t.is(config?.report, Report.detailed);
 });
 
+test.serial("args allow override query (.license-compliancerc.js)", async (t): Promise<void> => {
+    // No inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                query: ["MIT", "ISC"],
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+
+    // Command line args
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => <Configuration>{ allow: ["0BSD"] },
+        },
+    });
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.query.length, 0);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "0BSD");
+});
+
+test.serial("args query override allow (.license-compliancerc.js)", async (t): Promise<void> => {
+    // No inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                allow: ["MIT", "ISC"],
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+
+    // Command line args
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => <Configuration>{ query: ["0BSD"] },
+        },
+    });
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 0);
+    t.is(config?.query.length, 1);
+    t.is(config?.query[0], "0BSD");
+});
+
+test.serial("args allow override query (extended)", async (t): Promise<void> => {
+    // No inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                extends: "@acme/license-policy",
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: { query: ["MIT", "ISC"] },
+            filepath: "node_modules/@acme/license-policy/index.js",
+        }),
+    );
+
+    // Command line args
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => <Configuration>{ allow: ["0BSD"] },
+        },
+    });
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.query.length, 0);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "0BSD");
+});
+
+test.serial("args query override allow (extended)", async (t): Promise<void> => {
+    // No inline configuration
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                extends: "@acme/license-policy",
+            },
+            filepath: "some-path",
+            isEmpty: false,
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: { allow: ["MIT", "ISC"] },
+            filepath: "node_modules/@acme/license-policy/index.js",
+        }),
+    );
+
+    // Command line args
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Configuration => <Configuration>{ query: ["0BSD"] },
+        },
+    });
+
+    // Get configuration
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 0);
+    t.is(config?.query.length, 1);
+    t.is(config?.query[0], "0BSD");
+});
+
 function createExplorer(): Explorer {
     return {
         search: (): Promise<CosmiconfigResult> => Promise.resolve(null),


### PR DESCRIPTION
# Summary

If the `extended` module or the inline configuration `.license-compliancerc.js` has specified `allow`, packages cannot be queried using the command line `arguments`.

Addressed by:
```TypeScript
    // Allow and query mutual overrides
    if (configArgs.allow) {
        if (configExtended) {
            configExtended.query = [];
        }
        if (configInline) {
            configInline.query = [];
        }
    }
    if (configArgs.query) {
        if (configExtended) {
            configExtended.allow = [];
        }
        if (configInline) {
            configInline.allow = [];
        }
    }

```

Closes #258 