### PR TITLE
feat: add show config option

### DIFF
--- a/.license-compliancerc.js
+++ b/.license-compliancerc.js
@@ -1,10 +1,11 @@
 export default {
     allow: ["MIT", "0BSD", "BSD-3-Clause"],
-    development: true,
+    development: false,
     direct: true,
-    exclude: [/^spdx/, "yaml"],
+    exclude: [],
     // extends: "@tmorell/license-policy",
     format: "text",
     production: true,
+    query: [],
     report: "summary",
 };

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Packages
 - `-e, --exclude <packages>` Semicolon separated list of package names to be excluded from the analysis. Regex expressions are supported.
 - `-q, --query <licenses>` Semicolon separated list of licenses.
 - `-v, --version` Display license-compliance version
+- `-s, --show-config` Shows the configuration being used.
 - `-h, --help` Display help for command
 
 > `<licenses>` must conform to [SPDX](https://spdx.org/licenses) specifications.
@@ -148,6 +149,59 @@ export default {
 > `extends` must reference a package within the project's `node_modules` folder, preventing path traversal.
 
 > The configuration file `.license-compliancerc.js` can also include other properties besides `extends`, allowing to override the settings from the installed shared package. The command line arguments override any configuration; priority `CLI` > `.license-compliancerc.js` > `shared configuration package`.
+
+## Show Configuration
+
+There are three different sources to configure options, `args` > `inline (.license-compliancerc.js)` > `extended (module)`.
+`Show configuration` assists identifying or troubleshooting the source of the values. For example:
+
+args:
+
+```bash
+license-compliance -s -a "Apache-2.0"
+```
+
+.license-compliancerc.js:
+
+```javascript
+export default {
+    allow: ["MIT", "0BSD", "BSD-3-Clause"],
+    development: false,
+    direct: true,
+    extends: "@tmorell/license-policy",
+    format: "text",
+    production: true,
+    report: "summary",
+};
+```
+
+extended module:
+
+```javascript
+export default {
+    allow: ["MIT", "ISC"],
+    exclude: [/^@acme/],
+    format: "json",
+};
+```
+
+Outputs:
+
+```
+┌─────────────┬───────────────┬──────────────┬───────────────────────────┬────────────┐
+│ (index)     │ configuration │ args         │ inline                    │ extended   │
+├─────────────┼───────────────┼──────────────┼───────────────────────────┼────────────┤
+│ allow       │ 'Apache-2.0'  │ 'Apache-2.0' │ 'MIT, 0BSD, BSD-3-Clause' │ 'MIT, ISC' │
+│ development │ false         │ '-'          │ false                     │ '-'        │
+│ direct      │ true          │ '-'          │ true                      │ '-'        │
+│ exclude     │ '/^@acme/'    │ '-'          │ '-'                       │ '/^@acme/' │
+│ format      │ 'text'        │ '-'          │ 'text'                    │ 'json'     │
+│ production  │ true          │ '-'          │ true                      │ '-'        │
+│ query       │ '-'           │ '-'          │ '-'                       │ '-'        │
+│ report      │ 'summary'     │ '-'          │ 'summary'                 │ '-'        │
+│ showConfig  │ true          │ true         │ '-'                       │ '-'        │
+└─────────────┴───────────────┴──────────────┴───────────────────────────┴────────────┘
+```
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -86,9 +86,10 @@
         "debug:watch": "DEBUG=license-compliance:* DEBUG_COLORS=true tsc-watch --onSuccess 'node ./lib/index.js'",
         "lint": "eslint",
         "prettier": "prettier --check .",
-        "test": "ava",
-        "test:ci": "npm run c8",
-        "test:watch": "ava --watch"
+        "test": "npm run typecheck && ava",
+        "test:ci": "npm run typecheck && npm run c8",
+        "test:watch": "ava --watch",
+        "typecheck": "tsc --noEmit"
     },
     "type": "module",
     "types": "./lib/index.d.ts",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -89,6 +89,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         production: mergedConfiguration.production,
         query: mergedConfiguration.query || [],
         report: <Report>mergedConfiguration.report || Report.summary,
+        showConfig: mergedConfiguration.showConfig,
     };
 
     // Validate configuration
@@ -102,6 +103,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             production: joi.boolean().strict(),
             query: joiLicense("query"),
             report: joi.string().valid(Report.detailed, Report.summary),
+            showConfig: joi.boolean().strict(),
         })
         .messages({
             "any.only": "extended option {{#label}} value '{{#value}}' is invalid. Allowed choices are {{#valids}}.",
@@ -125,12 +127,56 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     configuration.development = !!configuration.development;
     configuration.direct = !!configuration.direct;
     configuration.production = !!configuration.production;
+    configuration.showConfig = !!configuration.showConfig;
+
+    if (configuration.showConfig) {
+        showConfig(configExtended, <Partial<Configuration>>configInline, configArgs, configuration);
+    }
 
     return configuration;
 }
 
 export function isComplianceModeEnabled(configuration: Pick<Configuration, "allow">): boolean {
     return Array.isArray(configuration.allow) && configuration.allow.length > 0;
+}
+
+function showConfig(
+    extended: Partial<Configuration>,
+    inline: Partial<Configuration>,
+    args: Configuration,
+    configuration: Configuration,
+): void {
+    inline ??= {};
+    extended ??= {};
+    const keys = <
+        Array<keyof Configuration> //
+    >Object.keys({ ...extended, ...inline, ...args, ...configuration }).toSorted((a, b): number => a.localeCompare(b));
+    const tableData: Record<string, Record<string, string>> = {};
+    for (const key of keys) {
+        tableData[key] = {
+            configuration: formatValue(configuration[key]),
+            args: formatValue(args[key]),
+            inline: formatValue(inline[key]),
+            extended: formatValue(extended[key]),
+        };
+    }
+    console.table(tableData);
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined || value === null) {
+        return "-";
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return "-";
+        }
+        return value.map((v): string => (v instanceof RegExp ? v.toString() : v)).join(", ");
+    }
+    if (typeof value === "boolean") {
+        return <string>(<unknown>value);
+    }
+    return <string>value;
 }
 
 function joiLicense(option: string): joi.ArraySchema<Array<string>> {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface Configuration {
     production: boolean;
     query: Array<string>;
     report: Report;
+    showConfig: boolean;
 }
 
 export interface ExtendableConfiguration extends Partial<Configuration> {

--- a/src/program.ts
+++ b/src/program.ts
@@ -25,6 +25,7 @@ export function processArgs(): Configuration {
         .option("-p, --production", "Analyzes only production dependencies.")
         .addOption(new Option("-d, --development", "Analyzes only development dependencies.").conflicts("production"))
         .option("-t, --direct", "Analyzes only direct dependencies (depth = 1).")
+        .option("-s, --show-config", "Shows the configuration being used.")
         .addOption(
             new Option("-f, --format <format>", "Report format, csv, text, or json (default = text).").choices(
                 Object.keys(Format),

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -76,6 +76,7 @@ test.serial("Command args success", async (t): Promise<void> => {
                     production: true,
                     query: [],
                     report: Report.detailed,
+                    showConfig: true,
                 };
             },
         },
@@ -93,6 +94,7 @@ test.serial("Command args success", async (t): Promise<void> => {
     t.true(config.production);
     t.is(config.query.length, 0);
     t.is(config.report, Report.detailed);
+    t.is(config.showConfig, true);
 });
 
 // Inline only
@@ -582,6 +584,7 @@ function assertDefaultConfig(t: ExecutionContext<unknown>, config: Configuration
     t.false(config?.production);
     t.is(config?.query.length, 0);
     t.is(config?.report, Report.summary);
+    t.is(config?.showConfig, false);
 }
 
 function getDefaultConfig(): Configuration {
@@ -594,5 +597,6 @@ function getDefaultConfig(): Configuration {
         production: false,
         query: [],
         report: Report.summary,
+        showConfig: false,
     };
 }

--- a/tests/main/main.spec.ts
+++ b/tests/main/main.spec.ts
@@ -225,6 +225,7 @@ function getMockConfiguration(overrideConfiguration?: Partial<Configuration>): C
             production: false,
             query: [],
             report: Report.summary,
+            showConfig: false,
         },
         overrideConfiguration,
     );

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -17,5 +17,6 @@ export function getDefaultConfiguration(): Configuration {
         format: Format.text,
         query: [],
         report: Report.summary,
+        showConfig: false,
     };
 }


### PR DESCRIPTION
# Summary

There are three different sources to configure options, `args` > `inline (.license-compliancerc.js)` > `extended (module)`.
`Show configuration` assists identifying or troubleshooting the source of the values. For example:

args:

```bash
license-compliance -s -a "Apache-2.0"
```

.license-compliancerc.js:

```javascript
export default {
    allow: ["MIT", "0BSD", "BSD-3-Clause"],
    development: false,
    direct: true,
    extends: "@tmorell/license-policy",
    format: "text",
    production: true,
    report: "summary",
};
```

extended module:

```javascript
export default {
    allow: ["MIT", "ISC"],
    exclude: [/^@acme/],
    format: "json",
};
```

Outputs:

```
┌─────────────┬───────────────┬──────────────┬───────────────────────────┬────────────┐
│ (index)     │ configuration │ args         │ inline                    │ extended   │
├─────────────┼───────────────┼──────────────┼───────────────────────────┼────────────┤
│ allow       │ 'Apache-2.0'  │ 'Apache-2.0' │ 'MIT, 0BSD, BSD-3-Clause' │ 'MIT, ISC' │
│ development │ false         │ '-'          │ false                     │ '-'        │
│ direct      │ true          │ '-'          │ true                      │ '-'        │
│ exclude     │ '/^@acme/'    │ '-'          │ '-'                       │ '/^@acme/' │
│ format      │ 'text'        │ '-'          │ 'text'                    │ 'json'     │
│ production  │ true          │ '-'          │ true                      │ '-'        │
│ query       │ '-'           │ '-'          │ '-'                       │ '-'        │
│ report      │ 'summary'     │ '-'          │ 'summary'                 │ '-'        │
│ showConfig  │ true          │ true         │ '-'                       │ '-'        │
└─────────────┴───────────────┴──────────────┴───────────────────────────┴────────────┘
```

Closes #295 