### PR TITLE
feat: add no-config option

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,14 +13,13 @@ import { isPathTraversalSafe } from "./util.js";
 const packageName = "license-compliance";
 
 export async function getConfiguration(nodeModulesPath: string): Promise<Configuration | null> {
-    let configExtended: Partial<Configuration> = {};
-
     // Get inline configuration
     const explorer = cosmiconfigPkg.cosmiconfig(packageName, { searchStrategy: "global" });
     const configResult = await explorer.search();
-    const configInline = <ExtendableConfiguration>configResult?.config;
+    let configInline = <ExtendableConfiguration>configResult?.config;
 
     // Get extended configuration
+    let configExtended: Partial<Configuration> = {};
     const extendsPath = configInline?.extends;
     if (extendsPath) {
         try {
@@ -34,7 +33,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
             }
 
             const c = await explorer.load(confPath);
-            configExtended = <Partial<Configuration>>c?.config || {};
+            configExtended = <Configuration>c?.config || {};
             delete configInline.extends;
         } catch (error: unknown) {
             if (error instanceof Error && "code" in error && error.code === "ENOENT") {
@@ -60,6 +59,12 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
         return null;
     }
 
+    // Discard inline and extended configuration if `no-config` in args.
+    if (!configArgs.config) {
+        configInline = {};
+        configExtended = {};
+    }
+
     // Allow and query mutual overrides
     if (configArgs.allow) {
         if (configExtended) {
@@ -79,9 +84,10 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     }
 
     // Merge configurations: args > inline > extended
-    const mergedConfiguration = { ...configExtended, ...(<Partial<Configuration>>configInline), ...configArgs };
+    const mergedConfiguration = { ...configExtended, ...(<Configuration>configInline), ...configArgs };
     const configuration = {
         allow: mergedConfiguration.allow || [],
+        config: mergedConfiguration.config,
         development: mergedConfiguration.development,
         direct: mergedConfiguration.direct,
         exclude: mergedConfiguration.exclude || [],
@@ -96,6 +102,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     const result = joi
         .object({
             allow: joiLicense("allow"),
+            config: joi.boolean().strict(),
             development: joi.boolean().strict(),
             direct: joi.boolean().strict(),
             exclude: joi.array(),
@@ -130,7 +137,7 @@ export async function getConfiguration(nodeModulesPath: string): Promise<Configu
     configuration.showConfig = !!configuration.showConfig;
 
     if (configuration.showConfig) {
-        showConfig(configExtended, <Partial<Configuration>>configInline, configArgs, configuration);
+        showConfig(configExtended, <Configuration>configInline, configArgs, configuration);
     }
 
     return configuration;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import { Format, LicenseStatus, Report } from "./enumerations.js";
 
 export interface Configuration {
     allow: Array<string>;
+    config: boolean;
     development: boolean;
     direct: boolean;
     exclude: Array<string | RegExp>;

--- a/src/program.ts
+++ b/src/program.ts
@@ -26,6 +26,7 @@ export function processArgs(): Configuration {
         .addOption(new Option("-d, --development", "Analyzes only development dependencies.").conflicts("production"))
         .option("-t, --direct", "Analyzes only direct dependencies (depth = 1).")
         .option("-s, --show-config", "Shows the configuration being used.")
+        .option("-c, --no-config", "Ignores configuration files and relies strictly on command-line arguments.")
         .addOption(
             new Option("-f, --format <format>", "Report format, csv, text, or json (default = text).").choices(
                 Object.keys(Format),

--- a/tests/configuration/getConfiguration.spec.ts
+++ b/tests/configuration/getConfiguration.spec.ts
@@ -6,6 +6,7 @@ import sinon from "sinon";
 import { getConfiguration as getConfigurationFunc } from "../../src/configuration.js";
 import { Format, Report } from "../../src/enumerations.js";
 import { Configuration } from "../../src/interfaces.js";
+import { getDefaultConfiguration } from "../util.js";
 
 const NODE_MODULES = "node_modules";
 
@@ -73,6 +74,7 @@ test.serial("Command args success", async (t): Promise<void> => {
                     direct: true,
                     exclude: [/@acme/],
                     format: Format.json,
+                    config: false,
                     production: true,
                     query: [],
                     report: Report.detailed,
@@ -482,7 +484,7 @@ test.serial("Hierarchy overwrite extended <- args", async (t): Promise<void> => 
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => {
-                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+                return { ...getDefaultConfiguration(), ...{ allow: ["MIT"] } };
             },
         },
     });
@@ -508,7 +510,7 @@ test.serial("Hierarchy overwrite inline <- args", async (t): Promise<void> => {
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => {
-                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+                return { ...getDefaultConfiguration(), ...{ allow: ["MIT"] } };
             },
         },
     });
@@ -544,7 +546,7 @@ test.serial("Hierarchy overwrite extended <- inline <- args", async (t): Promise
     const { getConfiguration } = await esmock("../../src/configuration.js", {
         "../../src/program.js": {
             processArgs: (): Configuration => {
-                return { ...getDefaultConfig(), ...{ allow: ["MIT"] } };
+                return { ...getDefaultConfiguration(), ...{ allow: ["MIT"] } };
             },
         },
     });
@@ -554,6 +556,50 @@ test.serial("Hierarchy overwrite extended <- inline <- args", async (t): Promise
     t.not(config, null);
     t.is(config?.allow.length, 1);
     t.is(config?.allow[0], "MIT");
+});
+
+// No config
+test.serial("No config", async (t): Promise<void> => {
+    const explorer: Explorer = createExplorer();
+    sinon.stub(cosmiconfig, "cosmiconfig").returns(explorer);
+    sinon.stub(explorer, "search").returns(
+        Promise.resolve({
+            config: {
+                extends: "@acme/license-policy",
+                report: Report.detailed,
+            },
+            filepath: "path",
+        }),
+    );
+    sinon.stub(explorer, "load").returns(
+        Promise.resolve({
+            config: {
+                format: Format.json,
+            },
+            filepath: "path",
+            isEmpty: false,
+        }),
+    );
+    const { getConfiguration } = await esmock("../../src/configuration.js", {
+        "../../src/program.js": {
+            processArgs: (): Partial<Configuration> => {
+                return {
+                    allow: ["MIT"],
+                    config: false,
+                    showConfig: true,
+                };
+            },
+        },
+    });
+
+    const config = await getConfiguration(NODE_MODULES);
+
+    t.not(config, null);
+    t.is(config?.allow.length, 1);
+    t.is(config?.allow[0], "MIT");
+    // Default values due to `no-config` discarding inline and extend
+    t.is(config?.format, Format.text);
+    t.is(config?.report, Report.summary);
 });
 
 // Utils
@@ -577,6 +623,7 @@ function createExplorer(): Explorer {
 function assertDefaultConfig(t: ExecutionContext<unknown>, config: Configuration | null): void {
     t.not(config, null);
     t.is(config?.allow.length, 0);
+    t.true(config?.config);
     t.false(config?.development);
     t.false(config?.direct);
     t.is(config?.exclude.length, 0);
@@ -585,18 +632,4 @@ function assertDefaultConfig(t: ExecutionContext<unknown>, config: Configuration
     t.is(config?.query.length, 0);
     t.is(config?.report, Report.summary);
     t.is(config?.showConfig, false);
-}
-
-function getDefaultConfig(): Configuration {
-    return {
-        allow: [],
-        development: false,
-        direct: false,
-        exclude: [],
-        format: Format.text,
-        production: false,
-        query: [],
-        report: Report.summary,
-        showConfig: false,
-    };
 }

--- a/tests/main/main.spec.ts
+++ b/tests/main/main.spec.ts
@@ -218,6 +218,7 @@ function getMockConfiguration(overrideConfiguration?: Partial<Configuration>): C
     return Object.assign(
         {
             allow: [],
+            config: true,
             development: false,
             direct: false,
             exclude: [],

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -10,6 +10,7 @@ export function readJson(path: string): unknown {
 export function getDefaultConfiguration(): Configuration {
     return {
         allow: [],
+        config: true,
         development: false,
         direct: false,
         exclude: [],


### PR DESCRIPTION
# Summary

Add option to bypass inline and extend, and use only args.
```
-c, --no-config", "Ignores configuration files and relies strictly on command-line arguments.
```

Closes #299 